### PR TITLE
Add/media file api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2138,6 +2138,11 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
+    "err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -2333,11 +2338,34 @@
         "pend": "~1.2.0"
       }
     },
+    "file-js": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/file-js/-/file-js-0.3.0.tgz",
+      "integrity": "sha1-+rRr94I0bJKUSZ8fDSrQfYOPJdE=",
+      "requires": {
+        "bluebird": "^3.4.7",
+        "minimatch": "^3.0.3",
+        "proper-lockfile": "^1.2.0"
+      }
+    },
     "file-saver": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
       "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg==",
       "dev": true
+    },
+    "filehound": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/filehound/-/filehound-1.16.4.tgz",
+      "integrity": "sha512-TElqcntG5el6W/RG7gMUiaJxy1xmJA+RQ+c7AOcOqgDOHNfR6vW8khMYp/oVXrFtI/SXV6vAUlt//5XMUAZBww==",
+      "requires": {
+        "bluebird": "^3.5.1",
+        "file-js": "0.3.0",
+        "lodash": "^4.17.10",
+        "minimatch": "^3.0.4",
+        "moment": "^2.22.1",
+        "unit-compare": "^1.0.1"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -4120,8 +4148,7 @@
     "moment": {
       "version": "2.22.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
-      "dev": true
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -5410,6 +5437,17 @@
         "object-assign": "^4.1.1"
       }
     },
+    "proper-lockfile": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
+      "integrity": "sha1-zv9d2J0+XxD7deHo52vHWAGlnDQ=",
+      "requires": {
+        "err-code": "^1.0.0",
+        "extend": "^3.0.0",
+        "graceful-fs": "^4.1.2",
+        "retry": "^0.10.0"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
@@ -5980,6 +6018,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
+    "retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
     },
     "right-align": {
       "version": "0.1.3",
@@ -6750,6 +6793,14 @@
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "unit-compare": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unit-compare/-/unit-compare-1.0.1.tgz",
+      "integrity": "sha1-DHRZ8OW/U2N+qHPKPO4Y3i7so4Y=",
+      "requires": {
+        "moment": "^2.14.1"
       }
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-preset-stage-2": "^6.24.1",
     "css-loader": "^0.26.1",
     "express": "^4.16.3",
+    "filehound": "^1.16.4",
     "foundation-sites": "^6.3.0",
     "html-webpack-plugin": "^2.22.0",
     "lodash": "^4.17.10",

--- a/src/server/media-server.js
+++ b/src/server/media-server.js
@@ -13,7 +13,6 @@ function findAndServeMedia(req, res, next) {
     if ( ! files.length ) 
       res.sendStatus( 404 );
 
-    console.log( files[ 0 ] );
     res.sendFile( files[ 0 ] );
   }, 
   () => {
@@ -22,7 +21,7 @@ function findAndServeMedia(req, res, next) {
 }
 
 function mediaServer( app ) {
-  app.use( '/api/media/:queryText', findAndServeMedia );
+  app.use( '/api/media/first/:queryText', findAndServeMedia );
 }
 
 module.exports = mediaServer;

--- a/src/server/media-server.js
+++ b/src/server/media-server.js
@@ -1,0 +1,28 @@
+const path = require('path');
+const FileHound = require('filehound');
+
+const mediaBaseFolder = path.join(process.env.HOME, '/Music/iTunes/iTunes Media/Music');
+
+function findAndServeMedia(req, res, next) {
+  const files = FileHound.create()
+    .paths( mediaBaseFolder )
+    .match( `*${ req.params.queryText }*` )
+    .find();
+
+  files.then( ( files ) => {
+    if ( ! files.length ) 
+      res.sendStatus( 404 );
+
+    console.log( files[ 0 ] );
+    res.sendFile( files[ 0 ] );
+  }, 
+  () => {
+    res.sendStatus( 404 );
+  });
+}
+
+function mediaServer( app ) {
+  app.use( '/api/media/:queryText', findAndServeMedia );
+}
+
+module.exports = mediaServer;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -26,7 +26,7 @@ app.use('/media', express.static(path.join(process.env.HOME, '/Music/iTunes/iTun
 
 // serve up iTunes media as a queryable API for easy access to audio without paths
 // for example:
-//  http://localhost:6041/api/media/20170709-padscape--manas-beat-alpine
+//  http://localhost:6041/api/media/first/20170709-padscape--manas-beat-alpine
 // returns the first file matching `*20170709-padscape--manas-beat-alpine*'
 mediaServer(app);
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -1,6 +1,8 @@
 const path = require('path')
-var express = require('express')
-var app = express();
+const express = require('express')
+const app = express();
+
+const mediaServer = require('./media-server')
 
 // dev or production (so we can serve up appropriate client stuff)
 const DEVELOPMENT = process.env.NODE_ENV === 'development';
@@ -22,8 +24,15 @@ else {
 // serve up iTunes media folder for easy access to audio
 app.use('/media', express.static(path.join(process.env.HOME, '/Music/iTunes/iTunes Media/Music')));
 
+// serve up iTunes media as a queryable API for easy access to audio without paths
+// for example:
+//  http://localhost:6041/api/media/20170709-padscape--manas-beat-alpine
+// returns the first file matching `*20170709-padscape--manas-beat-alpine*'
+mediaServer(app);
+
 // serve up Throwdown folder for easy access to snip / throwdown metadata
 app.use('/throwdown', express.static(path.join(process.env.HOME, '/Music/Throwdown')));
+
 
 // start http server
 app.listen(webPort);


### PR DESCRIPTION
Adds a lightweight API which allows searching for files (in the media folder) based on the name. Returns the first matching file. 

This allows the front end code to refer to audio files using a unique string in the name, rather than having to know exact full file path.