### PR TITLE
reuse players so can stop all and have local state

### DIFF
--- a/src/apps/throwdown/components/midi-loop-player.js
+++ b/src/apps/throwdown/components/midi-loop-player.js
@@ -6,9 +6,15 @@ import midiUtilities from '@kytaime/midi-utilities';
 
 class MidiLoopPlayer {
   constructor(props) {
-    this.props = _.defaults( props, MidiLoopPlayer.defaultProps );
+    this.updateProps( props );
+    
     this.throwdownRender = this.throwdownRender.bind(this);
   }
+
+  updateProps( props ) {
+    this.props = _.defaults( props, MidiLoopPlayer.defaultProps );
+  }
+
 
   getNotePattern() {
     // convert any named drum hits into general midi

--- a/src/apps/throwdown/components/midi-loop-player.js
+++ b/src/apps/throwdown/components/midi-loop-player.js
@@ -36,6 +36,10 @@ class MidiLoopPlayer {
     }
   }
 
+  stopPlayback() {
+    // we just let the current notes die
+  }
+
   throwdownRender( renderMsec, tempoBpm, renderBeats, midiOutPort ) {
     const currentPhraseLength = this.props.pattern.duration;
     const channel = this.props.channel;

--- a/src/apps/throwdown/components/sample-slice-player.js
+++ b/src/apps/throwdown/components/sample-slice-player.js
@@ -7,6 +7,12 @@ import patternSequencer from '@kytaime/sequencer/pattern-sequencer';
 
 class SampleSlicePlayer {
   constructor(props) {
+    this.updateProps( props );
+
+    this.playing = false;
+  }
+
+  updateProps( props ) {
     this.props = _.defaults( props, SampleSlicePlayer.defaultProps );
 
     if ( ! this.props.slices || ! this.props.slices.length  ) {
@@ -16,12 +22,8 @@ class SampleSlicePlayer {
         beat: 0,
       }];
     }
-
-    this.playing = false;
-
-    // this.loaded = false;
-    // this.loading = false;
   }
+
 
   playSliceAt( startTimestamp, stopTimestamp, startBeat, transportBpm, audioDestinationNode ) {
     // console.log( 
@@ -52,25 +54,12 @@ class SampleSlicePlayer {
   }
 
   throwdownRender( renderRange, tempoBpm, renderRangeBeats ) {
-    // if ( ! this.loaded && ! this.loading ) {
-    //   this.loading = true;
-    //   this.loaded = new Promise( ( resolve, reject ) => {      
-    //     audioUtilities.loadSample( this.props.audioFile, renderRange.audioContext, (buffer) => {
-    //       console.log( 'sample decoded, ready to play' );
-    //       this.buffer = buffer;
-    //       resolve();
-    //     } );
-    //   } );
-    // }
-
     if ( ! this.props.buffer ) {
       return;
     }
 
     let { sampleDuration } = this.props;
 
-    // note this loops forever unless we have triggered = false 
-    // so the stop logic is not being tested
     var triggered = true;
 
     let triggerInfo = patternSequencer.renderPatternTrigger(
@@ -82,7 +71,6 @@ class SampleSlicePlayer {
     );
 
     this.playing = triggerInfo.isPlaying;
-    // this.updatePlayingState( this.playing );
 
     let filteredSlices = _.filter(this.props.slices, function(sliceEvent) {
       return bpmUtilities.valueInWrappedBeatRange(
@@ -106,6 +94,7 @@ class SampleSlicePlayer {
     // const renderEventTime = (time) => (time) / 1000;
 
     _.map(scheduledSlices, (sliceRenderInfo) => {
+      console.log( `playing a slice ${ sliceRenderInfo.event.beat }@${ sliceRenderInfo.start } ${ this.audioFile } ` );
       const startTime = renderEventTime(sliceRenderInfo.start);
       const stopTime = renderEventTime(sliceRenderInfo.start + sliceRenderInfo.duration);
       this.playSliceAt( startTime, stopTime, sliceRenderInfo.event.beat, tempoBpm, renderRange.audioContext.destination );

--- a/src/apps/throwdown/components/sample-slice-player.js
+++ b/src/apps/throwdown/components/sample-slice-player.js
@@ -24,7 +24,6 @@ class SampleSlicePlayer {
     }
   }
 
-
   playSliceAt( startTimestamp, stopTimestamp, startBeat, transportBpm, audioDestinationNode ) {
     // console.log( 
     //   `-- beat playSliceAt ` +
@@ -51,6 +50,13 @@ class SampleSlicePlayer {
     player.stop( stopTimestamp );
 
     this.player = player;
+  }
+
+  stopPlayback() {
+    if ( this.player ) {
+      this.player.stop();
+      this.player = null;
+    }
   }
 
   throwdownRender( renderRange, tempoBpm, renderRangeBeats ) {
@@ -94,7 +100,7 @@ class SampleSlicePlayer {
     // const renderEventTime = (time) => (time) / 1000;
 
     _.map(scheduledSlices, (sliceRenderInfo) => {
-      console.log( `playing a slice ${ sliceRenderInfo.event.beat }@${ sliceRenderInfo.start } ${ this.audioFile } ` );
+      // console.log( `playing a slice ${ sliceRenderInfo.event.beat }@${ sliceRenderInfo.start } ${ this.audioFile } ` );
       const startTime = renderEventTime(sliceRenderInfo.start);
       const stopTime = renderEventTime(sliceRenderInfo.start + sliceRenderInfo.duration);
       this.playSliceAt( startTime, stopTime, sliceRenderInfo.event.beat, tempoBpm, renderRange.audioContext.destination );

--- a/src/apps/throwdown/components/throwdown/section-player.js
+++ b/src/apps/throwdown/components/throwdown/section-player.js
@@ -32,6 +32,13 @@ class SectionPlayer {
     } );
   }
 
+  stopPlayback() {
+    // stop pattern players
+    _.each( this.patternPlayers,  
+      player => player.stopPlayback() 
+    );
+  }
+
   throwdownRender( renderRange, tempoBpm, renderRangeBeats, midiOutPort ) {
     let triggerInfo = patternSequencer.renderPatternTrigger(
       tempoBpm, 

--- a/src/apps/throwdown/player-factory.js
+++ b/src/apps/throwdown/player-factory.js
@@ -5,36 +5,53 @@ import getChannelForPart from './get-channel-for-part';
 import MidiLoopPlayer from './components/midi-loop-player';
 import SampleSlicePlayer from './components/sample-slice-player';
 
-function playerFromFilePatternData( patternData, slug, buffers ) {
-  var channel = patternData.channel || getChannelForPart( patternData.part || slug );
+function getPlayerProps( patternData, buffers ) {
+  var channel = patternData.channel || getChannelForPart( patternData.part );
   if ( patternData.notes ) {
-    return new MidiLoopPlayer( {
+    return {
       channel: channel, 
       notes: patternData.notes,
       duration: patternData.duration,
       startBeats: patternData.startBeats,
       endBeats: patternData.endBeats,
-    } ) ;
+    };
   }
   if ( patternData.file ) {
     // const channel = getChannelForPart( resource.part || key );
     const stateBuffer = _.find( buffers, { file: patternData.file } );
     if ( ! stateBuffer ) {
-      return;
+      return null;
     }
-    return new SampleSlicePlayer( {
-      channel: channel, // not yet used!
+    return {
+      channel: channel,
       audioFile: patternData.file,
       buffer: stateBuffer.buffer,
       tempoBpm: patternData.tempo, 
       sampleDuration: patternData.duration,
       startBeats: patternData.startBeats,
       endBeats: patternData.endBeats,
-    } );
+      slices: patternData.slices,
+    };
+  }
+  return null;
+}
+
+function playerFromFilePatternData( patternData, buffers ) {
+  const props = getPlayerProps( patternData, buffers );
+  if ( ! props ) {
+    return null;
+  }
+
+  if ( patternData.notes ) {
+    return new MidiLoopPlayer( props );
+  }
+  if ( patternData.file ) {
+    return new SampleSlicePlayer( props );
   }
   return null;
 }
 
 export default {
   playerFromFilePatternData,
+  getPlayerProps,
 };

--- a/src/apps/throwdown/throwdown-app.js
+++ b/src/apps/throwdown/throwdown-app.js
@@ -171,6 +171,13 @@ class ThrowdownApp {
     } );
   }
 
+  stopAllPlayers() {
+    this.deckSectionPlayers.map( deckSectionItem => {
+      if ( deckSectionItem.sectionPlayer.stopPlayback ) {
+        deckSectionItem.sectionPlayer.stopPlayback();
+      }
+    } );       
+  }
 
   renderTimePeriod( renderRange, renderRangeBeats ) {
     // console.log( 
@@ -290,6 +297,7 @@ class ThrowdownApp {
   stopTransport() {
     sequencer.stop();
     this.lastRenderEndBeat = 0;
+    this.stopAllPlayers();
     store.dispatch( transportActions.setCurrentBeat( this.lastRenderEndBeat ) );
   }
   toggleTransport() {

--- a/src/apps/throwdown/throwdown-app.js
+++ b/src/apps/throwdown/throwdown-app.js
@@ -2,9 +2,6 @@ import _ from 'lodash';
 
 import store from './store/store';
 
-
-// import observeReduxStore from '@lib/observe-redux-store';
-
 import transportActions from './components/transport/actions';
 
 import throwdownActions from './components/throwdown/actions';
@@ -15,8 +12,6 @@ import patternSequencer from '@kytaime/sequencer/pattern-sequencer';
 import bpmUtilities from '@kytaime/sequencer/bpm-utilities';
 import midiPorts from '@kytaime/midi-ports';
 import audioUtilities from '@kytaime/audio-utilities';
-
-// import playerFactory from './player-factory';
 
 import SectionPlayer from './components/throwdown/section-player';
 
@@ -54,7 +49,8 @@ class ThrowdownApp {
     this.setNextTempo = this.setNextTempo.bind( this );
     this.renderTimePeriod = this.renderTimePeriod.bind( this );
 
-    this.temporaryDecks = [];
+    // array of { deckSlug: sectionSlug: sectionPlayer: }
+    this.deckSectionPlayers = [];
 
     sequencer.setRenderCallback( 'throwdown', this.sequencerCallback );
 
@@ -66,8 +62,6 @@ class ThrowdownApp {
     this.renderIndex = 0;
 
     this.openMidiOutput( "IAC Driver Bus 1" );
-
-    // observeReduxStore( store, throwdownSelectors.getThrowdown, this.importThrowdown );
   }
 
   importPatterns( songSlug, patterns ) {
@@ -105,18 +99,18 @@ class ThrowdownApp {
     this.nextTempoBpm = nextTempoBpm;
   }
 
-  // Ensure that we have players for each deck and pattern currently triggered or playing in state
-  // Currently making new ones each time – may retain them across renders,
-  // add new ones as needed, and update props from state
-  generateTemporaryDeckPlayers( state ) {
-    // const allSections = throwdownSelectors.getSections( state );
+  // creates new decks and players to match state
+  // will reuse existing decks, matching based on deck+section slug
+  updateDeckPlayers( state ) {
     const allBuffers = throwdownSelectors.getBuffers( state );
     const allDecks = throwdownSelectors.getDecks( state );
     const triggerLoop = throwdownSelectors.getTriggerLoop( state );
 
-    // instantiate players for ALL sections
-    this.temporaryDecks = _.map( allDecks, ( deckState ) => {
-      const sectionPlayers = _.map( deckState.sections, ( section ) => {
+    const deckSectionPlayers = this.deckSectionPlayers;
+
+    // { deckSlug: sectionSlug: sectionPlayer: }
+    _.map( allDecks, ( deckState ) => {
+      _.map( deckState.sections, ( section ) => {
         var patterns = throwdownSelectors.getDeckSectionPatterns( state, deckState.slug, section.slug ); 
 
         const sectionProps = {
@@ -125,41 +119,60 @@ class ThrowdownApp {
           buffers: allBuffers,
           patterns,
           triggerLoop,
+
+          // these are now props, in temporary approach they are this.members
+          triggered: ( section.slug === deckState.triggeredSection ),
+          playing: ( section.slug === deckState.playingSection ),
         }
-        const player = new SectionPlayer( sectionProps );
 
-        // sync relevant props (which things are triggered, playing) from state
-        player.triggered = ( section.slug === deckState.triggeredSection );
-        player.playing = ( section.slug === deckState.playingSection );
-        
-        return player;
+        var sectionDeckItem = _.find( deckSectionPlayers, { 
+          sectionSlug: section.slug,
+          deckSlug: deckState.slug,
+        } );
+
+        if ( sectionDeckItem ) {
+          sectionDeckItem.sectionPlayer.updateProps( sectionProps );
+        }
+        else {
+          deckSectionPlayers.push( {
+            sectionSlug: section.slug,
+            deckSlug: deckState.slug,
+            sectionPlayer: new SectionPlayer( sectionProps ),
+          } );
+        }
       } );
-
-      return { 
-        deckSlug: deckState.slug,
-        sectionPlayers,
-      }
     } );
   }
 
-  updateDeckPlayState( ) {
-    // const triggeredSection = null;
-    this.temporaryDecks.map( deck => {
-      var playingSection = null;
-      deck.sectionPlayers.map( sectionPlayer => {
-        if ( sectionPlayer.playing ) {
-          playingSection = sectionPlayer.props.slug;
-        }
-      } );
+  updateDeckPlayState_fromDeckPlayers( state ) {
+    const allDecks = throwdownSelectors.getDecks( state );
+    // init defaults (so when nothing is playing, we send a message for that)
+    var playingSectionByDeck = _.map( allDecks, ( deckState ) => { 
+      return { 
+        deckSlug: deckState.slug,
+        playingSection: null,
+      } 
+    } );
+    playingSectionByDeck = _.keyBy( playingSectionByDeck, 'deckSlug' );
+
+    // loop over all decks, finding the playing section
+    this.deckSectionPlayers.map( deckSectionPlayer => {
+      if ( deckSectionPlayer.sectionPlayer.props.playing ) {
+        playingSectionByDeck[ deckSectionPlayer.deckSlug ].playingSection = deckSectionPlayer.sectionPlayer.props.slug;
+      }
+    } );
+
+    // now send all the messages
+    _.map( playingSectionByDeck, deckSectionInfo => {
       store.dispatch( throwdownActions.setDeckPlayingSection( {
-        deckSlug: deck.deckSlug, 
-        sectionSlug: playingSection
+        deckSlug: deckSectionInfo.deckSlug, 
+        sectionSlug: deckSectionInfo.playingSection
       } ) );
     } );
   }
 
+
   renderTimePeriod( renderRange, renderRangeBeats ) {
-    // console.log(renderRange);
     // console.log( 
     //   `--- app renderTimePeriod ` +
     //   `current=(${ this.lastRenderEndBeat })` +
@@ -167,16 +180,13 @@ class ThrowdownApp {
     //   `end=(${ renderRangeBeats.end }, ${ renderRange.end }) `
     // );
 
-    // get children to render themselves
-    this.temporaryDecks.map( deck => {
-      deck.sectionPlayers.map( sectionPlayer => {
-        if ( sectionPlayer.throwdownRender ) {
-          sectionPlayer.throwdownRender( renderRange, this.tempo, renderRangeBeats, this.midiOutPort );
-        }
-      } );   
+    this.deckSectionPlayers.map( deckSectionItem => {
+      if ( deckSectionItem.sectionPlayer.throwdownRender ) {
+        deckSectionItem.sectionPlayer.throwdownRender( renderRange, this.tempo, renderRangeBeats, this.midiOutPort );
+      }
     } );   
+    this.updateDeckPlayState_fromDeckPlayers( store.getState() );
 
-    this.updateDeckPlayState();
 
     this.lastRenderEndBeat = renderRangeBeats.end; 
 
@@ -190,10 +200,7 @@ class ThrowdownApp {
   sequencerCallback( renderRange ) {
     this.renderIndex++;
 
-    // this will remake all the players every time
-    // in future it should make new ones + update props
-    // we're hooking this up manually here, on each render - but we could equally use observeReduxStore
-    this.generateTemporaryDeckPlayers( store.getState() );
+    this.updateDeckPlayers( store.getState() );
 
     // calculate render range in beats
     var chunkMs = renderRange.end - renderRange.start;
@@ -242,18 +249,11 @@ class ThrowdownApp {
       [ { start: 0, duration: 1 } ],
     );
 
-
-
-    // const tempoChangeAbsoluteBeat = tempoDropInfo.triggerOnset + Math.ceil( renderRange.start.beat / tempoChangePhrase ) * tempoChangePhrase;
     var renderRangeCurrent = _.cloneDeep( renderRange );
     var renderRangeNext = _.cloneDeep( renderRange );
     renderRangeCurrent.end = tempoChangeEvent[0].start;
     renderRangeNext.start = tempoChangeEvent[0].start;
     renderRangeNext.tempoBpm = this.nextTempoBpm;
-
-    // there's something broken for when we render renderRangeNext - when tempo changes
-    // the first audio sample slice is out by a little bit, presumably the length of renderRangeCurrent
-    // renderRangeNext.audioContextTimeOffsetMsec += renderRangeCurrent.end.time - renderRangeCurrent.start.time;
 
     var newTempo = this.nextTempoBpm;
     chunkBeats = bpmUtilities.msToBeats( this.tempoBpm, renderRangeCurrent.end - renderRangeCurrent.start );
@@ -270,7 +270,6 @@ class ThrowdownApp {
       start: this.lastRenderEndBeat, 
       end: this.lastRenderEndBeat + chunkBeats,
     } );
-
 
     // update the UI at the appropriate time
     setTimeout(() => {


### PR DESCRIPTION
Previously, all players were fully recreated every render loop.

This PR only creates new ones as needed, and updates the properties of the existing ones (inspired by react..). Each player can have local state.

In `SampleSlicePlayer` we use this state for a Web Audio node that's playing the current slice, and now we can stop all the currently playing stem slices when the main transport is stopped. 

In future we can use local state for longer-term fills, dynamic patterns etc, and keep this runtime content out of the main redux store.