### PR TITLE
show deck playing/triggered state & only include relevant decks in trigger phrase

### DIFF
--- a/src/apps/throwdown/components/playback-progress/deck-progress.jsx
+++ b/src/apps/throwdown/components/playback-progress/deck-progress.jsx
@@ -9,7 +9,9 @@ const mapStateToProps = ( state, ownProps ) => {
   const deckState = throwdownSelectors.getDeck( state, ownProps.deckSlug );
   const hue = deckState ? deckState.hue : 0;
 
-  const progressPercent = throwdownSelectors.getDeckPhraseProgress( state, ownProps.deckSlug ) * 100.0;
+  const progressPercent = deckState.playingSection ? 
+    throwdownSelectors.getDeckPhraseProgress( state, ownProps.deckSlug ) * 100.0 : 
+    0;
 
   return {
     progressPercent,

--- a/src/apps/throwdown/components/throwdown/deck-row.jsx
+++ b/src/apps/throwdown/components/throwdown/deck-row.jsx
@@ -41,6 +41,8 @@ function DeckSectionsTriggersComponent( props ) {
   const backgroundColour = deckColours.hueToBackgroundColour( props.deckState.hue );
   const edgeColour = deckColours.hueToBorderColour( props.deckState.hue );
   const deckSlug = props.deckState.slug;
+  const isTriggered = props.deckState.triggeredSection;
+  const isPlaying = props.deckState.playingSection;
 
   const sections = props.deckState.sections.map( 
     ( section ) => {
@@ -68,7 +70,8 @@ function DeckSectionsTriggersComponent( props ) {
       }}>
         {/* deck tempo, title, metadata */}
         <div style={{ 
-          fontWeight: 'bold'
+          fontWeight: isPlaying ? 'bold' : 'normal',
+          fontStyle: isTriggered ? 'italic' : 'normal',
         }}>{ deckSlug }</div>
       </td>
       

--- a/src/apps/throwdown/components/throwdown/selectors.js
+++ b/src/apps/throwdown/components/throwdown/selectors.js
@@ -82,7 +82,10 @@ function getAllDeckPatterns( state, deckSlug ) {
 
   const sectionPatterns = deckState.sections.map( section => {
     var patterns = section.patterns.map( 
-      patternSlug => _.find( allPatterns, { slug: patternSlug } )
+      patternSlug => _.find( allPatterns, { 
+        slug: patternSlug,
+        songSlug: deckState.slug,
+      } )
     );
     return _.filter( patterns ); // filter out undefined patterns, e.g. slug not present
   } );

--- a/src/apps/throwdown/components/throwdown/selectors.js
+++ b/src/apps/throwdown/components/throwdown/selectors.js
@@ -21,12 +21,18 @@ function getPhraseLoopFromPatterns( patterns ) {
 
 // this is the same for section | deck | global right now
 // in future they will be different
-// and it includes ALL patterns, not just those that are triggered/playing
-const getPhraseLoop = createSelector( 
-  [ 'throwdown.patterns' ],
-  getPhraseLoopFromPatterns,
-);
-
+function getPhraseLoop( state ) {
+  const decks = getDecks( state );
+  const relevantDecks = _.filter( decks, deck => {
+    return ( deck.playingSection || deck.triggeredSection );
+  } );
+  const relevantPhraseLoop = _.map( relevantDecks, deck => {
+    return getDeckPhraseLoop( state, deck.slug );
+  } );
+  return _.reduce( relevantPhraseLoop, ( phrase, deckPhrase ) => {
+    return Math.max( phrase, deckPhrase );
+  }, MIN_PHRASE_LENGTH );
+}
 
 const getTriggerLoop = createSelector( 
   [ 'throwdown.deferAllTriggers', getPhraseLoop ],


### PR DESCRIPTION
This PR makes it more apparent when deck rows are playing &/or triggered. The progress bar is only show when playing, and the deck name is bold/italic when playing/triggered.

Also in this PR, the trigger phrase & header progress now only includes decks that are triggered or playing.

<img width="896" alt="Screen Shot 2019-03-26 at 8 19 40 PM" src="https://user-images.githubusercontent.com/4167300/54978224-82704d80-5004-11e9-8f3d-afed0ae66617.png">

