### PR TITLE
Support drag & drop of throwdown files to end of list or to replace specific deck

### DIFF
--- a/src/apps/throwdown/components/drag-drop/actions.js
+++ b/src/apps/throwdown/components/drag-drop/actions.js
@@ -1,0 +1,7 @@
+import { createAction } from 'redux-starter-kit';
+
+const setDropHighlight = createAction( 'fileImport/setDropHighlight' );
+
+export default {
+  setDropHighlight,
+};

--- a/src/apps/throwdown/components/drag-drop/file-import.js
+++ b/src/apps/throwdown/components/drag-drop/file-import.js
@@ -67,8 +67,8 @@ function addThrowdownDeck( songSlug, throwdownData ) {
   // } ) );
 }
 
-function importThrowdownFile( deckSlug, file ) {
-  window.fetch( file )
+function importThrowdownFile( deckSlug, fileUrl ) {
+  window.fetch( fileUrl )
     .then( response => response.text() )
     .then( text => {
       const songData = Hjson.parse( text );
@@ -76,4 +76,12 @@ function importThrowdownFile( deckSlug, file ) {
     } );
 }
 
-export default importThrowdownFile;
+function importThrowdownData( deckSlug, hjsonBlob ) {
+  addThrowdownDeck( deckSlug, hjsonBlob );
+}
+
+
+export default { 
+  importThrowdownFile,
+  importThrowdownData,
+};

--- a/src/apps/throwdown/components/drag-drop/file-import.js
+++ b/src/apps/throwdown/components/drag-drop/file-import.js
@@ -38,7 +38,22 @@ function importPatterns( songSlug, patterns ) {
   } );  
 }
 
-function addThrowdownDeck( songSlug, throwdownData ) {
+function getUniqueImportSlug( slug, filename ) {
+  // ahem, need wurd() lib!
+  var uniqueSlug = slug || filename || 'new_' + Math.round( Math.random() * 99999 ) + '_guy';
+
+  // you're not leaving until you're unique
+  const decks = throwdownSelectors.getDecks( store.getState() );
+  while ( _.includes( _.map( decks, 'slug' ), uniqueSlug ) ) {
+    uniqueSlug += Math.round( Math.random() * 99 )
+  }
+
+  return uniqueSlug;
+}
+
+function addThrowdownDeck( filename, throwdownData ) {
+  const songSlug = getUniqueImportSlug( throwdownData.slug, filename );
+
   importPatterns( songSlug, throwdownData.patterns );
 
   store.dispatch( throwdownActions.addDeck( {
@@ -52,32 +67,19 @@ function addThrowdownDeck( songSlug, throwdownData ) {
       ...section
     } ) );
   } );
-
-  // trigger a random section
-  // const sectionSlugs = _.keys( throwdownData.sections );
-  // store.dispatch( throwdownActions.setDeckTriggeredSection( {
-  //   deckSlug: songSlug,
-  //   sectionSlug: _.sample( sectionSlugs )
-  // } ) );
-
-  // hard code build for testing
-  // store.dispatch( throwdownActions.setDeckTriggeredSection( {
-  //   deckSlug: 'test',
-  //   sectionSlug: 'build',
-  // } ) );
 }
 
-function importThrowdownFile( deckSlug, fileUrl ) {
+function importThrowdownFile( fileUrl ) {
   window.fetch( fileUrl )
     .then( response => response.text() )
     .then( text => {
       const songData = Hjson.parse( text );
-      addThrowdownDeck( deckSlug, songData );
+      addThrowdownDeck( fileUrl, songData );
     } );
 }
 
-function importThrowdownData( deckSlug, hjsonBlob ) {
-  addThrowdownDeck( deckSlug, hjsonBlob );
+function importThrowdownData( filename, hjsonBlob ) {
+  addThrowdownDeck( filename, hjsonBlob );
 }
 
 

--- a/src/apps/throwdown/components/drag-drop/file-import.js
+++ b/src/apps/throwdown/components/drag-drop/file-import.js
@@ -51,13 +51,14 @@ function getUniqueImportSlug( slug, filename ) {
   return uniqueSlug;
 }
 
-function addThrowdownDeck( filename, throwdownData ) {
+function addThrowdownDeck( filename, throwdownData, replaceDeckRowSlug ) {
   const songSlug = getUniqueImportSlug( throwdownData.slug, filename );
 
   importPatterns( songSlug, throwdownData.patterns );
 
   store.dispatch( throwdownActions.addDeck( {
     deckSlug: songSlug,
+    replaceDeckSlug: replaceDeckRowSlug
   } ) ); 
   
   _.map( throwdownData.sections, ( section, key ) => {
@@ -67,6 +68,8 @@ function addThrowdownDeck( filename, throwdownData ) {
       ...section
     } ) );
   } );
+
+  return songSlug;
 }
 
 function importThrowdownFile( fileUrl ) {
@@ -78,10 +81,9 @@ function importThrowdownFile( fileUrl ) {
     } );
 }
 
-function importThrowdownData( filename, hjsonBlob ) {
-  addThrowdownDeck( filename, hjsonBlob );
+function importThrowdownData( filename, hjsonBlob, replaceDeckRowSlug ) {
+  addThrowdownDeck( filename, hjsonBlob, replaceDeckRowSlug );
 }
-
 
 export default { 
   importThrowdownFile,

--- a/src/apps/throwdown/components/drag-drop/ghost-deck.jsx
+++ b/src/apps/throwdown/components/drag-drop/ghost-deck.jsx
@@ -64,15 +64,21 @@ document.addEventListener('dragleave', resetDragState );
 
 document.addEventListener('drop', event => { 
   event.preventDefault(); 
+
+  // should really loop and import each file as new deck
   if (event.dataTransfer.files.length >= 1) {
+    const filename = event.dataTransfer.files[0].name;
     const fileReader = new FileReader();
+
     fileReader.onloadend = ( loadedEvent ) => {
       const importRaw = loadedEvent.currentTarget.result;
       var importContent = Hjson.parse( importRaw );
-      fileImport.importThrowdownData( 'dropped', importContent );
+      fileImport.importThrowdownData( filename, importContent );
     }
+
     fileReader.readAsText( event.dataTransfer.files[0] );
   }
+
   resetDragState();
 } );
 

--- a/src/apps/throwdown/components/drag-drop/ghost-deck.jsx
+++ b/src/apps/throwdown/components/drag-drop/ghost-deck.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Hjson from 'hjson';
+
+import { connect } from 'react-redux';
+
+import store from '../../store/store';
+
+import selectors from './selectors';
+import actions from './actions';
+
+import fileImport from './file-import';
+
+function GhostDeckComponent( props ) {
+  var classes = "deck-row deck-row-drophint ";
+  if ( props.highlighted ) {
+    classes += "deck-row-drophint-highlighted ";
+  }
+
+  return (
+    <tr className={ classes } >
+      {/* this is here to expand the background to full width */}
+      <td colSpan="99"></td> 
+    </tr>
+
+  );
+}
+
+GhostDeckComponent.propTypes = {
+  highlighted: PropTypes.bool,
+}
+
+const mapStateToProps = ( state, ownProps ) => {
+  const dragState = selectors.getDragDrop( state, ownProps.slug );
+  
+  return {
+    highlighted: dragState.dropHighlightAddNew
+  }
+}
+
+const mapDispatchToProps = ( dispatch, ownProps ) => {
+  return {
+  }
+}
+
+const GhostDeck = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(GhostDeckComponent)
+
+document.addEventListener('dragover', event => {
+  event.preventDefault();
+  store.dispatch( actions.setDropHighlight( {
+    addNew: true,
+  } ) );
+} );
+
+function resetDragState( event ) {
+  store.dispatch( actions.setDropHighlight() );
+}
+document.addEventListener('dragend', resetDragState );
+document.addEventListener('dragleave', resetDragState );
+
+document.addEventListener('drop', event => { 
+  event.preventDefault(); 
+  if (event.dataTransfer.files.length >= 1) {
+    const fileReader = new FileReader();
+    fileReader.onloadend = ( loadedEvent ) => {
+      const importRaw = loadedEvent.currentTarget.result;
+      var importContent = Hjson.parse( importRaw );
+      fileImport.importThrowdownData( 'dropped', importContent );
+    }
+    fileReader.readAsText( event.dataTransfer.files[0] );
+  }
+  resetDragState();
+} );
+
+export default GhostDeck;

--- a/src/apps/throwdown/components/drag-drop/ghost-deck.jsx
+++ b/src/apps/throwdown/components/drag-drop/ghost-deck.jsx
@@ -52,7 +52,7 @@ const GhostDeck = connect(
 document.addEventListener('dragover', event => {
   event.preventDefault();
   store.dispatch( actions.setDropHighlight( {
-    addNew: true,
+    dropHighlightAddNew: true,
   } ) );
 } );
 

--- a/src/apps/throwdown/components/drag-drop/ghost-deck.jsx
+++ b/src/apps/throwdown/components/drag-drop/ghost-deck.jsx
@@ -109,17 +109,17 @@ const BackgroundDropTarget = connect(
 
         // should really loop and import each file as new deck
         // this blob should be a method
-        if (event.dataTransfer.files.length >= 1) {
-          const filename = event.dataTransfer.files[0].name;
+        for ( var i=0; i<event.dataTransfer.files.length; i++) {
+          const file = event.dataTransfer.files[i];
           const fileReader = new FileReader();
 
           fileReader.onloadend = ( loadedEvent ) => {
             const importRaw = loadedEvent.currentTarget.result;
             var importContent = Hjson.parse( importRaw );
-            fileImport.importThrowdownData( filename, importContent, ownProps.slug );
+            fileImport.importThrowdownData( file.name, importContent, ownProps.slug );
           }
 
-          fileReader.readAsText( event.dataTransfer.files[0] );
+          fileReader.readAsText( file );
         }
 
         // share this aka resetDragState

--- a/src/apps/throwdown/components/drag-drop/reducer.js
+++ b/src/apps/throwdown/components/drag-drop/reducer.js
@@ -1,0 +1,25 @@
+import { createReducer } from 'redux-starter-kit';
+
+import actions from './actions';
+
+const fileImportReducer = createReducer( {
+  dropHighlightDeck: '', 
+  dropHighlightAddNew: false,
+}, {
+  [ actions.setDropHighlight ]: ( state, action ) => {
+    if ( action.payload && action.payload.deckSlug ) {
+      state.dropHighlightDeck = action.payload.deckSlug;
+      state.dropHighlightAddNew = false;
+    }
+    else if ( action.payload && action.payload.addNew ) {
+      state.dropHighlightDeck = '';
+      state.dropHighlightAddNew = true;
+    }
+    else {
+      state.dropHighlightDeck = '';
+      state.dropHighlightAddNew = false; 
+    }
+  },
+} );
+
+export default fileImportReducer;

--- a/src/apps/throwdown/components/drag-drop/reducer.js
+++ b/src/apps/throwdown/components/drag-drop/reducer.js
@@ -7,11 +7,11 @@ const fileImportReducer = createReducer( {
   dropHighlightAddNew: false,
 }, {
   [ actions.setDropHighlight ]: ( state, action ) => {
-    if ( action.payload && action.payload.deckSlug ) {
-      state.dropHighlightDeck = action.payload.deckSlug;
+    if ( action.payload && action.payload.dropHighlightDeck ) {
+      state.dropHighlightDeck = action.payload.dropHighlightDeck;
       state.dropHighlightAddNew = false;
     }
-    else if ( action.payload && action.payload.addNew ) {
+    else if ( action.payload && action.payload.dropHighlightAddNew ) {
       state.dropHighlightDeck = '';
       state.dropHighlightAddNew = true;
     }

--- a/src/apps/throwdown/components/drag-drop/selectors.js
+++ b/src/apps/throwdown/components/drag-drop/selectors.js
@@ -1,0 +1,7 @@
+import { createSelector } from 'redux-starter-kit';
+
+const getDragDrop = createSelector( [ 'dragDrop' ] );
+
+export default {
+  getDragDrop,
+};

--- a/src/apps/throwdown/components/file-import/file-import.js
+++ b/src/apps/throwdown/components/file-import/file-import.js
@@ -1,0 +1,79 @@
+import _ from 'lodash'; 
+
+import Hjson from 'hjson';
+
+import store from '../../store/store';
+
+import throwdownActions from '../throwdown/actions';
+import throwdownSelectors from '../throwdown/selectors';
+
+import sequencer from '@kytaime/sequencer/sequencer';
+import audioUtilities from '@kytaime/audio-utilities';
+
+function ensureAudioBuffered( audioContext, buffers, filename ) {
+  if ( _.find( buffers, { file: filename } ) ) {
+    return;
+  }
+  audioUtilities.loadSample( filename, audioContext, ( buffer ) => {
+    console.log( `sample decoded, ready to play ${ filename }` );
+    store.dispatch( throwdownActions.addAudioBuffer( {
+      file: filename,
+      buffer: buffer,
+    } ) );
+  } );
+}
+
+function importPatterns( songSlug, patterns ) {
+  const buffers = throwdownSelectors.getBuffers( store.getState() );
+
+  _.map( patterns, ( pattern, key ) => {
+    store.dispatch( throwdownActions.addPattern( {
+      songSlug, 
+      slug: key, 
+      ...pattern
+    } ) );
+    if ( pattern.file ) {
+      ensureAudioBuffered( sequencer.audioContext, buffers, pattern.file );
+    }
+  } );  
+}
+
+function addThrowdownDeck( songSlug, throwdownData ) {
+  importPatterns( songSlug, throwdownData.patterns );
+
+  store.dispatch( throwdownActions.addDeck( {
+    deckSlug: songSlug,
+  } ) ); 
+  
+  _.map( throwdownData.sections, ( section, key ) => {
+    store.dispatch( throwdownActions.addSection( {
+      deckSlug: songSlug,
+      slug: key, 
+      ...section
+    } ) );
+  } );
+
+  // trigger a random section
+  // const sectionSlugs = _.keys( throwdownData.sections );
+  // store.dispatch( throwdownActions.setDeckTriggeredSection( {
+  //   deckSlug: songSlug,
+  //   sectionSlug: _.sample( sectionSlugs )
+  // } ) );
+
+  // hard code build for testing
+  // store.dispatch( throwdownActions.setDeckTriggeredSection( {
+  //   deckSlug: 'test',
+  //   sectionSlug: 'build',
+  // } ) );
+}
+
+function importThrowdownFile( deckSlug, file ) {
+  window.fetch( file )
+    .then( response => response.text() )
+    .then( text => {
+      const songData = Hjson.parse( text );
+      addThrowdownDeck( deckSlug, songData );
+    } );
+}
+
+export default importThrowdownFile;

--- a/src/apps/throwdown/components/throwdown/deck-colours.js
+++ b/src/apps/throwdown/components/throwdown/deck-colours.js
@@ -1,8 +1,8 @@
 import Color from 'color'; 
 
-function hueToBackgroundColour( hue ) {
+function hueToBackgroundColour( hue, highlighted ) {
  return Color.hsl(
-    Math.floor( hue ), 75, 90,
+    Math.floor( hue ), 75, highlighted ? 85 : 90,
   ).hex();
 } 
 

--- a/src/apps/throwdown/components/throwdown/reducer.js
+++ b/src/apps/throwdown/components/throwdown/reducer.js
@@ -63,13 +63,13 @@ const throwdownReducer = createReducer( {
       slug: action.payload.deckSlug,
     };
 
-    if ( action.payload.replaceDeckSlug ) {
+    const shuntedDeck = getDeck( state, action.payload.replaceDeckSlug );
+    const insertPosition = _.findIndex( state.decks, { slug: action.payload.replaceDeckSlug } );
+    if ( action.payload.replaceDeckSlug && insertPosition !== -1 ) {
       // if we're "replacing" a deck row, reorder decks so added one is in that slot
-      // and the replaced deck is shunted to the bottom
-      const shuntedDeck = getDeck( state, action.payload.replaceDeckSlug );
+      state.decks.splice( insertPosition, 0, newDeck );
       _.remove( state.decks, shuntedDeck );
       state.decks.push( shuntedDeck );
-      state.decks.unshift( newDeck );
     }
     else {
       // otherwise just add at the end of the list
@@ -83,9 +83,7 @@ const throwdownReducer = createReducer( {
 
     deck.sections.push( {
       slug: action.payload.slug,
-
-      duration: action.payload.bars * 4,
-      
+      duration: action.payload.bars * 4,      
       patterns: action.payload.patterns,
     } );
   },

--- a/src/apps/throwdown/components/throwdown/reducer.js
+++ b/src/apps/throwdown/components/throwdown/reducer.js
@@ -58,10 +58,23 @@ const throwdownReducer = createReducer( {
     const deck = getDeck( state, action.payload.deckSlug );
     if ( deck ) return;
 
-    state.decks.push( {
+    const newDeck = {
       ...createDeck(),
       slug: action.payload.deckSlug,
-    } );
+    };
+
+    if ( action.payload.replaceDeckSlug ) {
+      // if we're "replacing" a deck row, reorder decks so added one is in that slot
+      // and the replaced deck is shunted to the bottom
+      const shuntedDeck = getDeck( state, action.payload.replaceDeckSlug );
+      _.remove( state.decks, shuntedDeck );
+      state.decks.push( shuntedDeck );
+      state.decks.unshift( newDeck );
+    }
+    else {
+      // otherwise just add at the end of the list
+      state.decks.push( newDeck );
+    }
   },
 
   [ actions.addSection ]: ( state, action ) => {

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -1,11 +1,7 @@
-import _ from 'lodash'; 
-
 import React from 'react';
 import { render } from 'react-dom';
 
 import { Provider } from 'react-redux';
-
-import Hjson from 'hjson';
 
 import store from './store/store';
 import observeStore from '@lib/observe-redux-store';
@@ -16,8 +12,7 @@ import Header from './components/transport-header/header.jsx';
 import HeaderPlaybackProgress from './components/playback-progress/header-progress.jsx';
 import Decks from './components/throwdown/decks.jsx';
 
-
-import throwdownActions from './components/throwdown/actions';
+import importThrowdownFile from './components/file-import/file-import';
 
 import './style/style.scss';
 
@@ -26,51 +21,8 @@ import './style/style.scss';
 
 const throwdownApp = new ThrowdownApp();
 
-
 /// -----------------------------------------------------------------------------------------------
 // load hard-coded test data
-
-function addThrowdownDeck( songSlug, throwdownData ) {
-  throwdownApp.importPatterns( songSlug, throwdownData.patterns );
-
-  store.dispatch( throwdownActions.addDeck( {
-    deckSlug: songSlug,
-  } ) ); 
-  
-  _.map( throwdownData.sections, ( section, key ) => {
-    store.dispatch( throwdownActions.addSection( {
-      deckSlug: songSlug,
-      slug: key, 
-      ...section
-    } ) );
-  } );
-
-  // trigger a random section
-  // const sectionSlugs = _.keys( throwdownData.sections );
-  // store.dispatch( throwdownActions.setDeckTriggeredSection( {
-  //   deckSlug: songSlug,
-  //   sectionSlug: _.sample( sectionSlugs )
-  // } ) );
-
-  // hard code build for testing
-  // store.dispatch( throwdownActions.setDeckTriggeredSection( {
-  //   deckSlug: 'test',
-  //   sectionSlug: 'build',
-  // } ) );
-}
-
-// const testSongFile = '/data/20190217--manas.hjson';
-// const testSongFile = 'data/20190306--sweets-from-a-stranger.hjson';
-// const testSongFile = 'data/20190306--its-not-real.hjson';
-
-function importThrowdownFile( deckSlug, file ) {
-  window.fetch( file )
-    .then( response => response.text() )
-    .then( text => {
-      const songData = Hjson.parse( text );
-      addThrowdownDeck( deckSlug, songData );
-    } );
-}
 
 importThrowdownFile( 'manas', '/data/20190217--manas.hjson' );
 // importThrowdownFile( 'noyu', '/data/20190325--noyu.hjson' );
@@ -79,7 +31,7 @@ importThrowdownFile( 'manas', '/data/20190217--manas.hjson' );
 // importThrowdownFile( 'maenyb', 'data/20190325--maenyb.hjson' );
 // importThrowdownFile( 'shedout', 'data/20190325--shedout.hjson' );
 // importThrowdownFile( 'mivova', 'data/20190325--mivova.hjson' );
-// importThrowdownFile( 'kufca', 'data/20190325--kufca.hjson' );
+importThrowdownFile( 'kufca', 'data/20190325--kufca.hjson' );
 
 /// -----------------------------------------------------------------------------------------------
 // bind sequencer/transport to store

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -144,3 +144,7 @@ render(
   document.getElementById('app')
 );
 
+// disable default drag handling on doc
+document.addEventListener('dragover', event => event.preventDefault())
+document.addEventListener('drop', event => event.preventDefault())
+

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -12,7 +12,8 @@ import Header from './components/transport-header/header.jsx';
 import HeaderPlaybackProgress from './components/playback-progress/header-progress.jsx';
 import Decks from './components/throwdown/decks.jsx';
 
-import importThrowdownFile from './components/file-import/file-import';
+import fileImport from './components/drag-drop/file-import';
+import GhostDeck from './components/drag-drop/ghost-deck.jsx';
 
 import './style/style.scss';
 
@@ -24,14 +25,14 @@ const throwdownApp = new ThrowdownApp();
 /// -----------------------------------------------------------------------------------------------
 // load hard-coded test data
 
-importThrowdownFile( 'manas', '/data/20190217--manas.hjson' );
+fileImport.importThrowdownFile( 'manas', '/data/20190217--manas.hjson' );
 // importThrowdownFile( 'noyu', '/data/20190325--noyu.hjson' );
 // importThrowdownFile( 'axbdmt', '/data/20190325--alex-haszard-bdmt.hjson' );
 // importThrowdownFile( 'sweets', 'data/20190306--sweets-from-a-stranger.hjson' );
 // importThrowdownFile( 'maenyb', 'data/20190325--maenyb.hjson' );
 // importThrowdownFile( 'shedout', 'data/20190325--shedout.hjson' );
 // importThrowdownFile( 'mivova', 'data/20190325--mivova.hjson' );
-importThrowdownFile( 'kufca', 'data/20190325--kufca.hjson' );
+fileImport.importThrowdownFile( 'kufca', 'data/20190325--kufca.hjson' );
 
 /// -----------------------------------------------------------------------------------------------
 // bind sequencer/transport to store
@@ -85,6 +86,7 @@ function App() {
           <Header />
           <HeaderPlaybackProgress backgroundColour="#ccc" progressColour="#888" />
           <Decks />
+          <GhostDeck />
         </tbody>
       </table>
     </Provider>
@@ -96,7 +98,4 @@ render(
   document.getElementById('app')
 );
 
-// disable default drag handling on doc
-document.addEventListener('dragover', event => event.preventDefault())
-document.addEventListener('drop', event => event.preventDefault())
 

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -13,7 +13,7 @@ import HeaderPlaybackProgress from './components/playback-progress/header-progre
 import Decks from './components/throwdown/decks.jsx';
 
 import fileImport from './components/drag-drop/file-import';
-import GhostDeck from './components/drag-drop/ghost-deck.jsx';
+import importDrop from './components/drag-drop/ghost-deck.jsx';
 
 import './style/style.scss';
 
@@ -81,12 +81,13 @@ observeStore(
 function App() {
   return (
     <Provider store={ store }>
-      <table cellSpacing="0" >
+      <importDrop.BackgroundDropTarget />
+      <table className="throwdown-container" cellSpacing="0" >
         <tbody>
           <Header />
           <HeaderPlaybackProgress backgroundColour="#ccc" progressColour="#888" />
           <Decks />
-          <GhostDeck />
+          <importDrop.GhostDeck />
         </tbody>
       </table>
     </Provider>

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -25,14 +25,14 @@ const throwdownApp = new ThrowdownApp();
 /// -----------------------------------------------------------------------------------------------
 // load hard-coded test data
 
-fileImport.importThrowdownFile( 'manas', '/data/20190217--manas.hjson' );
-// importThrowdownFile( 'noyu', '/data/20190325--noyu.hjson' );
-// importThrowdownFile( 'axbdmt', '/data/20190325--alex-haszard-bdmt.hjson' );
-// importThrowdownFile( 'sweets', 'data/20190306--sweets-from-a-stranger.hjson' );
-// importThrowdownFile( 'maenyb', 'data/20190325--maenyb.hjson' );
-// importThrowdownFile( 'shedout', 'data/20190325--shedout.hjson' );
-// importThrowdownFile( 'mivova', 'data/20190325--mivova.hjson' );
-fileImport.importThrowdownFile( 'kufca', 'data/20190325--kufca.hjson' );
+fileImport.importThrowdownFile( '/data/20190217--manas.hjson' );
+// importThrowdownFile( '/data/20190325--noyu.hjson' );
+// importThrowdownFile( '/data/20190325--alex-haszard-bdmt.hjson' );
+// importThrowdownFile( 'data/20190306--sweets-from-a-stranger.hjson' );
+// importThrowdownFile( 'data/20190325--maenyb.hjson' );
+// importThrowdownFile( 'data/20190325--shedout.hjson' );
+// importThrowdownFile( 'data/20190325--mivova.hjson' );
+fileImport.importThrowdownFile( 'data/20190325--kufca.hjson' );
 
 /// -----------------------------------------------------------------------------------------------
 // bind sequencer/transport to store

--- a/src/apps/throwdown/store/store.js
+++ b/src/apps/throwdown/store/store.js
@@ -2,11 +2,13 @@ import { configureStore } from 'redux-starter-kit';
 
 import transportReducer from '../components/transport/reducer';
 import throwdownReducer from '../components/throwdown/reducer';
+import dragDropReducer from '../components/drag-drop/reducer';
 
 const store = configureStore({
   reducer: {
     throwdown: throwdownReducer,
     transport: transportReducer,
+    dragDrop: dragDropReducer,
   }
 })
 export default store;

--- a/src/apps/throwdown/style/style.scss
+++ b/src/apps/throwdown/style/style.scss
@@ -49,3 +49,16 @@ td {
   width: 70px;
   text-align: right;
 }
+
+.deck-row-drophint {
+  background: transparent;
+}
+
+.deck-row-drophint td {
+  padding: 0;
+  height: 30px;
+}
+
+.deck-row-drophint.deck-row-drophint-highlighted {
+  background: #eee;
+}

--- a/src/apps/throwdown/style/style.scss
+++ b/src/apps/throwdown/style/style.scss
@@ -18,6 +18,11 @@ input {
   font-size: 1em;
 }
 
+.throwdown-container {
+  // this allows us to underlay .background-target for catching events 
+  position: relative;
+}
+
 th {
   font-weight: normal;
   min-width: 100px;
@@ -60,5 +65,18 @@ td {
 }
 
 .deck-row-drophint.deck-row-drophint-highlighted {
+  background: #eee;
+}
+
+
+.background-target {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.background-target.background-target-highlighted {
   background: #eee;
 }

--- a/src/apps/throwdown/throwdown-app.js
+++ b/src/apps/throwdown/throwdown-app.js
@@ -11,27 +11,10 @@ import sequencer from '@kytaime/sequencer/sequencer';
 import patternSequencer from '@kytaime/sequencer/pattern-sequencer';
 import bpmUtilities from '@kytaime/sequencer/bpm-utilities';
 import midiPorts from '@kytaime/midi-ports';
-import audioUtilities from '@kytaime/audio-utilities';
 
 import SectionPlayer from './components/throwdown/section-player';
 
 import './components/hardware-bindings/akai-apc40';
-
-/// -----------------------------------------------------------------------------------------------
-// sequencer core
-
-function ensureAudioBuffered( audioContext, buffers, filename ) {
-  if ( _.find( buffers, { file: filename } ) ) {
-    return;
-  }
-  audioUtilities.loadSample( filename, audioContext, ( buffer ) => {
-    console.log( `sample decoded, ready to play ${ filename }` );
-    store.dispatch( throwdownActions.addAudioBuffer( {
-      file: filename,
-      buffer: buffer,
-    } ) );
-  } );
-}
 
 class ThrowdownApp {
   constructor(props) {
@@ -64,20 +47,6 @@ class ThrowdownApp {
     this.openMidiOutput( "IAC Driver Bus 1" );
   }
 
-  importPatterns( songSlug, patterns ) {
-    const buffers = throwdownSelectors.getBuffers( store.getState() );
-
-    _.map( patterns, ( pattern, key ) => {
-      store.dispatch( throwdownActions.addPattern( {
-        songSlug, 
-        slug: key, 
-        ...pattern
-      } ) );
-      if ( pattern.file ) {
-        ensureAudioBuffered( sequencer.audioContext, buffers, pattern.file );
-      }
-    } );  
-  }
   openMidiOutput(requestedPortName) {
     midiPorts.openMidiOutput({
       deviceName: requestedPortName,

--- a/src/data/20190217--manas.hjson
+++ b/src/data/20190217--manas.hjson
@@ -1,5 +1,6 @@
 {
   version: 1
+  slug: manas
   patterns: {
     beat-step: {
       part: beat

--- a/src/data/20190306--its-not-real.hjson
+++ b/src/data/20190306--its-not-real.hjson
@@ -1,5 +1,6 @@
 {
   version: 1
+  slug: it's not real
   patterns: {
     beat0: {
       part: beat

--- a/src/data/20190306--sweets-from-a-stranger.hjson
+++ b/src/data/20190306--sweets-from-a-stranger.hjson
@@ -1,5 +1,6 @@
 {
   version: 1
+  slug: sweets
   patterns: {
     beat: {
       part: beat

--- a/src/data/20190325--alex-haszard-bdmt.hjson
+++ b/src/data/20190325--alex-haszard-bdmt.hjson
@@ -1,5 +1,6 @@
 {
   version: 1
+  slug: axbdmt
   patterns: {
     drums: {
       part: beat

--- a/src/data/20190325--kufca.hjson
+++ b/src/data/20190325--kufca.hjson
@@ -1,5 +1,6 @@
 {
   version: 1
+  slug: kufca
   patterns: {
     beat: {
       part: beat

--- a/src/data/20190325--maenyb.hjson
+++ b/src/data/20190325--maenyb.hjson
@@ -1,5 +1,6 @@
 {
   version: 1
+  slug: maenyb
   patterns: {
     beat: {
       part: beat

--- a/src/data/20190325--mivova.hjson
+++ b/src/data/20190325--mivova.hjson
@@ -1,5 +1,6 @@
 {
   version: 1
+  slug: mivova
   patterns: {
     beat: {
       part: beat

--- a/src/data/20190325--noyu.hjson
+++ b/src/data/20190325--noyu.hjson
@@ -1,5 +1,6 @@
 {
   version: 1
+  slug: noyu
   patterns: {
     beat: {
       part: beat

--- a/src/data/20190325--shedout.hjson
+++ b/src/data/20190325--shedout.hjson
@@ -1,5 +1,6 @@
 {
   version: 1
+  slug: shedout
   patterns: {
     beat: {
       part: beat


### PR DESCRIPTION
- Drag file(s) onto background – will add deck for each file at end of list.
- Drag file onto an existing deck row – will replace that deck, and shunt the replaced deck to the bottom of the list. This preserves the other decks' vertical order (e.g. if hardware mapped), but keeps the replaced deck in case it's playing or otherwise useful.