### PR TITLE
share pattern players across deck sections

### DIFF
--- a/src/apps/throwdown/components/midi-loop-player.js
+++ b/src/apps/throwdown/components/midi-loop-player.js
@@ -48,6 +48,7 @@ class MidiLoopPlayer {
 
   stopPlayback() {
     // we just let the current notes die
+    this.playing = false;
   }
 
   throwdownRender( renderMsec, tempoBpm, renderBeats, midiOutPort ) {

--- a/src/apps/throwdown/components/sample-slice-player.js
+++ b/src/apps/throwdown/components/sample-slice-player.js
@@ -95,6 +95,7 @@ class SampleSlicePlayer {
   stopPlayback() {
     if ( this.player ) {
       this.player.stop();
+      this.playing = false;
       this.player = null;
     }
   }

--- a/src/apps/throwdown/components/throwdown/deck-player.js
+++ b/src/apps/throwdown/components/throwdown/deck-player.js
@@ -30,8 +30,6 @@ class DeckPlayer {
         patternPlayer.updateProps( playerFactory.getPlayerProps( pattern, props.buffers ) );
       }
     } );
-
-    // console.log( 'DeckPlayer.patternPlayers=', this.patternPlayers );
   }
 
   stopPlayback() {
@@ -42,9 +40,9 @@ class DeckPlayer {
   }
 
   throwdownRender( renderRange, tempoBpm, renderRangeBeats, midiOutPort ) {
-    console.log( `DeckPlayer render ${ renderRangeBeats.start } ${ renderRangeBeats.end }` );
+    // console.log( `DeckPlayer render ${ renderRangeBeats.start } ${ renderRangeBeats.end }` );
 
-    // get sections that we need to consider:
+    // get sections that we need to evaluate triggering:
     // the playing one (if any) 
     // and the triggered one (if any)
     const playingSection = _.find( this.props.sections, { slug: this.props.playingSection } );
@@ -62,10 +60,8 @@ class DeckPlayer {
         ( playingSection.slug == this.props.triggeredSection ),
         ( playingSection.slug == this.props.playingSection ),
         this.props.triggerLoop,
-        // start beats and end beats for section .. is that a thing??
       );
       if ( triggerInfo.isPlaying ) {
-        // update props.playingSection if we are switching section
         currentPlayingSection = playingSection.slug;
       }
     }
@@ -77,70 +73,36 @@ class DeckPlayer {
         ( triggeredSection.slug == this.props.triggeredSection ),
         ( triggeredSection.slug == this.props.playingSection ),
         this.props.triggerLoop,
-        // start beats and end beats for section .. is that a thing??
       );
       if ( triggerInfo.isPlaying ) {
-        // update props.playingSection if we are switching section
         currentPlayingSection = triggeredSection.slug;  
       }
     }
-    // we don't use any of that – we just need triggered
-    // no, we still need it, because we tell Throwdown which section is playing!
 
+    // this is used by parent (throwdown) to send message to update UI
     this.props.playingSection = currentPlayingSection;
-    console.log( this.props.playingSection );
 
     // render patterns that are in the triggered/playing section
     _.each( this.patternPlayers,  
       ( player, patternSlug ) => {
-        // is this relevant - is it in the playing or triggered section? 
-        // if not, continue
-        const isInPlayingSection = playingSection ? _.includes( playingSection.patterns, patternSlug ) : false;
         const isInTriggeredSection = triggeredSection ? _.includes( triggeredSection.patterns, patternSlug ) : false;
 
-        if ( isInPlayingSection ) {
-          player.setParentTriggered( true );
-        }
-        else if ( isInTriggeredSection ) {
-          player.setParentTriggered( true );
-        }
-        // else {
-        //   return;
-        // }
-
+        player.setParentTriggered( isInTriggeredSection );
         player.setParentPhrase( this.props.triggerLoop );
         player.throwdownRender( renderRange, tempoBpm, renderRangeBeats, midiOutPort );
-
-        console.log( player );
       }
     );
-
-
-    // this.props.playing = triggerInfo.isPlaying;
-
-    // console.log( `${ this.props.slug } t=${ this.props.triggered } p=${ this.props.playing }` );
-  
-    // temporary - this really needs to be passed down to patterns as triggered: false
-    // so they can finish playing, etc
-    // if ( ! this.props.playing ) {
-    //   return;
-    // }
 
   }
 }
 
 DeckPlayer.defaultProps = {
   slug: '',
-  // pass the patterns that are used in this deck
-  // (we rely on client doing that for us)
   patterns: [],
-  // all the sections
-  // - patterns
-  // - triggered
-  // - playing
   sections: [], 
   buffers: [],
-  // 
+  playingSection: '',
+  triggeredSection: '',
   triggerLoop: 4,
 };
 

--- a/src/apps/throwdown/components/throwdown/deck-player.js
+++ b/src/apps/throwdown/components/throwdown/deck-player.js
@@ -1,0 +1,132 @@
+
+import _ from 'lodash';
+
+import patternSequencer from '@kytaime/sequencer/pattern-sequencer';
+
+import playerFactory from '../../player-factory';
+
+// import throwdownActions from './actions';
+
+
+class DeckPlayer {
+  constructor( props ) {
+
+    this.patternPlayers = {};
+
+    this.updateProps( props );
+  }
+
+  updateProps( props ) {
+    this.props = _.defaults( props, DeckPlayer.defaultProps );
+
+    // create/update one player for each pattern
+    _.each( props.patterns, ( pattern ) => {
+      var patternPlayer = this.patternPlayers[ pattern.slug ];
+      if ( ! patternPlayer ) {
+        patternPlayer = playerFactory.playerFromFilePatternData( pattern, props.buffers );
+        this.patternPlayers[ pattern.slug ] = patternPlayer;
+      }
+      else {
+        patternPlayer.updateProps( playerFactory.getPlayerProps( pattern, props.buffers ) );
+      }
+    } );
+  }
+
+  stopPlayback() {
+    // stop pattern players
+    _.each( this.patternPlayers,  
+      player => player.stopPlayback() 
+    );
+  }
+
+  throwdownRender( renderRange, tempoBpm, renderRangeBeats, midiOutPort ) {
+    // get sections that we need to consider:
+    // the playing one (if any) 
+    // and the triggered one (if any)
+    const playingSection = _.find( this.props.sections, { playing: true } );
+    const triggeredSection = _.find( this.props.sections, { triggered: true } );
+
+    // run triggering for playing & triggered sections
+    // we'll pass this down to the patterns so they know how to behave
+    const playingTriggerInfo = patternSequencer.renderPatternTrigger(
+      tempoBpm, 
+      renderRangeBeats,
+      playingSection.triggered,
+      playingSection.playing, 
+      this.props.triggerLoop,
+      // start beats and end beats for section .. is that a thing??
+    );
+    const triggeredTriggerInfo = patternSequencer.renderPatternTrigger(
+      tempoBpm, 
+      renderRangeBeats,
+      triggeredSection.triggered,
+      triggeredSection.playing, 
+      this.props.triggerLoop,
+      // start beats and end beats for section .. is that a thing??
+    );
+    // we don't use any of that – we just need triggered
+    // no, we still need it, because we tell Throwdown which section is playing!
+    if ( triggeredTriggerInfo.isPlaying ) {
+      this.props.playingSection = triggeredSection.slug;
+    }
+    else if ( playingTriggerInfo.isPlaying ) {
+      this.props.playingSection = playingSection.slug;
+    }
+    else {
+      this.props.playingSection = null;
+    }
+
+    // render patterns that are in the triggered/playing section
+    _.each( this.patternPlayers,  
+      ( player, patternSlug ) => {
+        // is this relevant - is it in the playing or triggered section? 
+        // if not, continue
+        const isInPlayingSection = _.contains( playingSection.patterns, patternSlug );
+        const isInTriggeredSection = _.contains( triggeredSection.patterns, patternSlug );
+
+        if ( isInPlayingSection ) {
+          player.setParentTriggered( playingSection.triggered );
+        }
+        else if ( isInTriggeredSection ) {
+          player.setParentTriggered( triggeredSection.triggered );
+        }
+        else {
+          return;
+        }
+
+        player.setParentPhrase( this.props.triggerLoop );
+        player.throwdownRender( renderRange, tempoBpm, renderRangeBeats, midiOutPort );
+      }
+    );
+
+
+    // this.props.playing = triggerInfo.isPlaying;
+
+    // console.log( `${ this.props.slug } t=${ this.props.triggered } p=${ this.props.playing }` );
+  
+    // temporary - this really needs to be passed down to patterns as triggered: false
+    // so they can finish playing, etc
+    // if ( ! this.props.playing ) {
+    //   return;
+    // }
+
+  }
+}
+
+DeckPlayer.defaultProps = {
+  slug: '',
+  // pass the patterns that are used in this deck
+  // (we rely on client doing that for us)
+  patterns: [],
+  // all the sections
+  // - patterns
+  // - triggered
+  // - playing
+  sections: [], 
+  buffers: [],
+  // 
+  triggerLoop: 4,
+};
+
+
+export default DeckPlayer;

--- a/src/apps/throwdown/components/throwdown/selectors.js
+++ b/src/apps/throwdown/components/throwdown/selectors.js
@@ -52,6 +52,14 @@ function getDeck( state, deckSlug ) {
   );
 }
 
+function getDeckSections( state, deckSlug ) {
+  const deckState = getDeck( state, deckSlug );
+  if ( ! deckState ) 
+    return;
+
+  return deckState.sections;
+}
+
 function getDeckSection( state, deckSlug, sectionSlug ) {
   const deckState = getDeck( state, deckSlug );
   if ( ! deckState ) 
@@ -115,6 +123,7 @@ export default {
   getDeck,
   getDeckPhraseLoop,
   getDeckPhraseProgress,
+  getDeckSections,
   getDeckSection,
   getDeckSectionPatterns,
   getAllDeckPatterns,

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -32,7 +32,7 @@ fileImport.importThrowdownFile( '/data/20190217--manas.hjson' );
 // importThrowdownFile( 'data/20190325--maenyb.hjson' );
 // importThrowdownFile( 'data/20190325--shedout.hjson' );
 // importThrowdownFile( 'data/20190325--mivova.hjson' );
-fileImport.importThrowdownFile( 'data/20190325--kufca.hjson' );
+// fileImport.importThrowdownFile( 'data/20190325--kufca.hjson' );
 
 /// -----------------------------------------------------------------------------------------------
 // bind sequencer/transport to store

--- a/src/apps/throwdown/throwdown-app.js
+++ b/src/apps/throwdown/throwdown-app.js
@@ -12,7 +12,8 @@ import patternSequencer from '@kytaime/sequencer/pattern-sequencer';
 import bpmUtilities from '@kytaime/sequencer/bpm-utilities';
 import midiPorts from '@kytaime/midi-ports';
 
-import SectionPlayer from './components/throwdown/section-player';
+// import SectionPlayer from './components/throwdown/section-player';
+import DeckPlayer from './components/throwdown/deck-player';
 
 import './components/hardware-bindings/akai-apc40';
 
@@ -34,7 +35,7 @@ class ThrowdownApp {
 
     // array of { deckSlug: sectionSlug: sectionPlayer: }
     // this.deckSectionPlayers = [];
-    this.deckPlayers = [];
+    this.deckPlayers = {};
 
     sequencer.setRenderCallback( 'throwdown', this.sequencerCallback );
 
@@ -91,8 +92,8 @@ class ThrowdownApp {
           triggerLoop,
 
           // these are now props, in temporary approach they are this.members
-          // triggered: ( section.slug === deckState.triggeredSection ),
-          // playing: ( section.slug === deckState.playingSection ),
+          triggeredSection: deckState.triggeredSection,
+          playingSection: deckState.playingSection,
         }
 
         var deckItem = deckPlayers[ deckState.slug ];
@@ -101,24 +102,25 @@ class ThrowdownApp {
           deckItem.updateProps( deckProps );
         }
         else {
-          deckPlayers[ deckState.slug ] = new SectionPlayer( deckProps );
+          deckPlayers[ deckState.slug ] = new DeckPlayer( deckProps );
         }
 
       // _.map( deckState.sections, ( section ) => {
 
       // } );
     } );
+
+    // console.log( this.deckPlayers );
   }
 
-  updateDeckPlayState_fromDeckPlayers( state ) {
+  updateDeckPlayState_fromDeckPlayers() {
     // const allDecks = throwdownSelectors.getDecks( state );
 
     _.map( this.deckPlayers, deckPlayer => {
       store.dispatch( throwdownActions.setDeckPlayingSection( {
-        deckSlug: deckPlayer.slug, 
+        deckSlug: deckPlayer.props.slug, 
         sectionSlug: deckPlayer.props.playingSection
       } ) );
-
     } );
 
     // // init defaults (so when nothing is playing, we send a message for that)
@@ -147,7 +149,7 @@ class ThrowdownApp {
   }
 
   stopAllPlayers() {
-    this.deckPlayers.map( deckPlayer => {
+    _.map( this.deckPlayers, deckPlayer => {
       deckPlayer.stopPlayback();
     } );       
   }
@@ -160,12 +162,12 @@ class ThrowdownApp {
     //   `end=(${ renderRangeBeats.end }, ${ renderRange.end }) `
     // );
 
-    this.deckPlayers.map( deckPlayer => {
+    _.map( this.deckPlayers, deckPlayer => {
       // if ( deckSectionItem.sectionPlayer.throwdownRender ) {
-        deckPlayer.throwdownRender( renderRange, this.tempo, renderRangeBeats, this.midiOutPort );
+        deckPlayer.throwdownRender( renderRange, this.tempoBpm, renderRangeBeats, this.midiOutPort );
       // }
     } );   
-    this.updateDeckPlayState_fromDeckPlayers( store.getState() );
+    this.updateDeckPlayState_fromDeckPlayers();
 
 
     this.lastRenderEndBeat = renderRangeBeats.end; 

--- a/src/data/20190217--manas.hjson
+++ b/src/data/20190217--manas.hjson
@@ -157,24 +157,24 @@
     }
   }
   sections: {
-    beat: {
-      bars: 8
-      patterns: [
-        beat-step
-      ]
-    }
-    voc: {
-      bars: 8
-      patterns: [
-        voc
-      ]
-    }
-    bass: {
-      bars: 8
-      patterns: [
-        sub
-      ]
-    }
+    # beat: {
+    #   bars: 8
+    #   patterns: [
+    #     beat-step
+    #   ]
+    # }
+    # voc: {
+    #   bars: 8
+    #   patterns: [
+    #     voc
+    #   ]
+    # }
+    # bass: {
+    #   bars: 8
+    #   patterns: [
+    #     sub
+    #   ]
+    # }
     beatbass: {
       bars: 8
       patterns: [
@@ -201,7 +201,7 @@
       bars: 8
       patterns: [
         beat-step
-        voc
+        arp
       ]
     }
   } 

--- a/src/data/20190217--manas.hjson
+++ b/src/data/20190217--manas.hjson
@@ -20,7 +20,7 @@
       file: '/media/Haszari/Haszari%20Renders%20-%20Snips%20Stems%20Padded%20Landscape/20170709-padscape--manas-voc-hills.m4a'
       tempo: 132,
       duration: 32
-      startBeats: [ 16, 28 ] 
+      startBeats: [ 28 ] 
     }
     sub: {
       duration: 4
@@ -54,8 +54,8 @@
     }
     arp: {
       duration: 16,
-      startBeats: [ 0, 0.5 ]
-      endBeats: [ 0, 15 ]
+      # startBeats: [ 0, 0.5 ]
+      # endBeats: [ 0, 15 ]
       notes: [
         {
           "note": 69,
@@ -194,6 +194,7 @@
       patterns: [
         beat-step
         sub
+        arp
         voc
       ]
     }


### PR DESCRIPTION
Now players are managed per deck (row).

This means that the same player can be used when transitioning between different sections. This prevents overlap of duplicate notes (e.g when a pattern is configured with a start pos that overlaps end pos, e.g. start 1 beat before end of bar, end at 0). 

In future this might allow players to perform fills or transitions automatically.