### PR TITLE
support different songs + sections within deck row

### DIFF
--- a/src/apps/throwdown/components/drag-drop/file-import.js
+++ b/src/apps/throwdown/components/drag-drop/file-import.js
@@ -67,12 +67,43 @@ function addThrowdownDeck( filename, throwdownData, replaceDeckRowSlug ) {
   return songSlug;
 }
 
+function addSectionsToDeck( filename, throwdownData, deckSlug ) {
+  const songSlug = getUniqueImportSlug( throwdownData.slug, filename );
+
+  importPatterns( songSlug, throwdownData.patterns );
+
+  // store.dispatch( throwdownActions.addDeck( {
+  //   deckSlug: songSlug,
+  //   replaceDeckSlug: replaceDeckRowSlug,
+  // } ) );
+
+  _.map( throwdownData.sections, ( section, key ) => {
+    store.dispatch( throwdownActions.addSection( {
+      songSlug: songSlug,
+      deckSlug: deckSlug,
+      slug: `${ songSlug }-${ key }`,
+      ...section,
+    } ) );
+  } );
+
+  return deckSlug;
+}
+
 function importThrowdownFile( fileUrl ) {
   window.fetch( fileUrl )
     .then( response => response.text() )
     .then( text => {
       const songData = Hjson.parse( text );
       addThrowdownDeck( fileUrl, songData );
+    } );
+}
+
+function importThrowdownFileToDeck( fileUrl, deckSlug ) {
+  window.fetch( fileUrl )
+    .then( response => response.text() )
+    .then( text => {
+      const songData = Hjson.parse( text );
+      addSectionsToDeck( fileUrl, songData, deckSlug );
     } );
 }
 
@@ -83,4 +114,5 @@ function importThrowdownData( filename, hjsonBlob, replaceDeckRowSlug ) {
 export default {
   importThrowdownFile,
   importThrowdownData,
+  importThrowdownFileToDeck,
 };

--- a/src/apps/throwdown/components/drag-drop/file-import.js
+++ b/src/apps/throwdown/components/drag-drop/file-import.js
@@ -81,7 +81,7 @@ function addSectionsToDeck( filename, throwdownData, deckSlug ) {
     store.dispatch( throwdownActions.addSection( {
       songSlug: songSlug,
       deckSlug: deckSlug,
-      slug: `${ songSlug }-${ key }`,
+      slug: key,
       ...section,
     } ) );
   } );

--- a/src/apps/throwdown/components/throwdown/deck-player.js
+++ b/src/apps/throwdown/components/throwdown/deck-player.js
@@ -87,18 +87,18 @@ class DeckPlayer {
         tempoBpm,
         renderRangeBeats,
         _.isEqual( this.props.triggeredSection, {
-          song: playingSection.song,
-          section: playingSection.section,
+          song: playingSection.songSlug,
+          section: playingSection.slug,
         } ),
         _.isEqual( this.props.playingSection, {
-          song: playingSection.song,
-          section: playingSection.section,
+          song: playingSection.songSlug,
+          section: playingSection.slug,
         } ),
         this.props.triggerLoop
       );
       if ( currentSectionTrigger.isPlaying ) {
         currentPlayingSection = {
-          song: playingSection.song,
+          song: playingSection.songSlug,
           section: playingSection.slug,
         };
       }
@@ -109,18 +109,18 @@ class DeckPlayer {
         tempoBpm,
         renderRangeBeats,
         _.isEqual( this.props.triggeredSection, {
-          song: triggeredSection.song,
-          section: triggeredSection.section,
+          song: triggeredSection.songSlug,
+          section: triggeredSection.slug,
         } ),
         _.isEqual( this.props.playingSection, {
-          song: triggeredSection.song,
-          section: triggeredSection.section,
+          song: triggeredSection.songSlug,
+          section: triggeredSection.slug,
         } ),
         this.props.triggerLoop
       );
       if ( nextSectionTrigger.isPlaying ) {
         currentPlayingSection = {
-          song: triggeredSection.song,
+          song: triggeredSection.songSlug,
           section: triggeredSection.slug,
         };
       }
@@ -149,7 +149,7 @@ class DeckPlayer {
     // console.log( `DeckPlayer ${ this.props.slug } renderTimePeriod ${ renderRange.start }/${ renderRangeBeats.start } ${ renderRange.end }/${ renderRangeBeats.end }` );
 
     const patternPlayStates = [];
-    const deckSlug = this.props.slug;
+    // const deckSlug = this.props.slug;
 
     // render patterns that are in the triggered/playing section
     _.each( this.patternPlayers,

--- a/src/apps/throwdown/components/throwdown/deck-player.js
+++ b/src/apps/throwdown/components/throwdown/deck-player.js
@@ -65,8 +65,6 @@ class DeckPlayer {
     // update props.playingSection if we are switching section
     var currentPlayingSection = null;
 
-    const deckSlug = this.props.slug;
-
     // run triggering for playing & triggered sections
     // we'll pass this down to the patterns so they know how to behave
     // these two ifs should be a function??
@@ -121,6 +119,7 @@ class DeckPlayer {
     // console.log( `DeckPlayer ${ this.props.slug } renderTimePeriod ${ renderRange.start }/${ renderRangeBeats.start } ${ renderRange.end }/${ renderRangeBeats.end }` );
 
     const patternPlayStates = [];
+    const deckSlug = this.props.slug;
 
     // render patterns that are in the triggered/playing section
     _.each( this.patternPlayers,
@@ -143,6 +142,7 @@ class DeckPlayer {
         player.throwdownRender( renderRange, tempoBpm, renderRangeBeats, midiOutPort );
 
         const stillPlaying = player.playing;
+
         // console.log( `play ${ patternSlug } inTriggeredSection=${ isInTriggeredSection } isTriggered=${ isTriggered } was=${ wasPlaying } now=${ stillPlaying }` );
         patternPlayStates.push( {
           // note here we are assuming deck === song

--- a/src/apps/throwdown/components/throwdown/deck-row.jsx
+++ b/src/apps/throwdown/components/throwdown/deck-row.jsx
@@ -39,9 +39,10 @@ function DeckSectionsTriggersComponent( props ) {
         section: section.slug,
         song: section.songSlug,
       };
+      const key = `${ section.songSlug }-${ section.slug }`;
       return (
         <SectionTrigger
-          key={ section.slug }
+          key={ key }
           triggered={ _.isEqual( props.deckState.triggeredSection, songSection ) }
           playing={ _.isEqual( props.deckState.playingSection, songSection ) }
           songSlug={ section.songSlug }

--- a/src/apps/throwdown/components/throwdown/deck-row.jsx
+++ b/src/apps/throwdown/components/throwdown/deck-row.jsx
@@ -19,12 +19,18 @@ import fileImport from '../drag-drop/file-import';
 
 import SectionTrigger from './section.jsx';
 
+function songSectionIsValid( songSection ) {
+  if ( ! songSection ) { return false; }
+
+  return ( songSection.section && songSection.song );
+}
+
 function DeckSectionsTriggersComponent( props ) {
   const backgroundColour = deckColours.hueToBackgroundColour( props.deckState.hue, props.highlighted );
   const edgeColour = deckColours.hueToBorderColour( props.deckState.hue );
   const deckSlug = props.deckState.slug;
-  const isTriggered = props.deckState.triggeredSection;
-  const isPlaying = props.deckState.playingSection;
+  const isTriggered = songSectionIsValid( props.deckState.triggeredSection );
+  const isPlaying = songSectionIsValid( props.deckState.playingSection );
 
   const sections = props.deckState.sections.map(
     ( section ) => {

--- a/src/apps/throwdown/components/throwdown/deck-row.jsx
+++ b/src/apps/throwdown/components/throwdown/deck-row.jsx
@@ -32,6 +32,9 @@ function DeckSectionsTriggersComponent( props ) {
   const isTriggered = songSectionIsValid( props.deckState.triggeredSection );
   const isPlaying = songSectionIsValid( props.deckState.playingSection );
 
+  const playingSong = props.deckState.playingSection ? props.deckState.playingSection.song : null;
+  const playingSection = props.deckState.playingSection ? props.deckState.playingSection.section : null;
+
   const sections = props.deckState.sections.map(
     ( section ) => {
       // const state = _.find( props.deckState, { 'slug': section.slug } ) || {};
@@ -47,6 +50,8 @@ function DeckSectionsTriggersComponent( props ) {
           playing={ _.isEqual( props.deckState.playingSection, songSection ) }
           songSlug={ section.songSlug }
           slug={ section.slug }
+          playingSong={ playingSong }
+          playingSection={ playingSection }
           onSetTriggeredSection={ props.onSetTriggeredSection }
           onSetPartTriggeredSection={ props.onSetPartTriggeredSection }
           hue={ props.deckState.hue }

--- a/src/apps/throwdown/components/throwdown/deck-row.jsx
+++ b/src/apps/throwdown/components/throwdown/deck-row.jsx
@@ -29,11 +29,16 @@ function DeckSectionsTriggersComponent( props ) {
   const sections = props.deckState.sections.map(
     ( section ) => {
       // const state = _.find( props.deckState, { 'slug': section.slug } ) || {};
+      const songSection = {
+        section: section.slug,
+        song: section.songSlug,
+      };
       return (
         <SectionTrigger
           key={ section.slug }
-          triggered={ props.deckState.triggeredSection === section.slug }
-          playing={ props.deckState.playingSection === section.slug }
+          triggered={ _.isEqual( props.deckState.triggeredSection, songSection ) }
+          playing={ _.isEqual( props.deckState.playingSection, songSection ) }
+          songSlug={ section.songSlug }
           slug={ section.slug }
           onSetTriggeredSection={ props.onSetTriggeredSection }
           onSetPartTriggeredSection={ props.onSetPartTriggeredSection }
@@ -107,10 +112,11 @@ const mapStateToProps = ( state, ownProps ) => {
 
 const mapDispatchToProps = ( dispatch, ownProps ) => {
   return {
-    onSetTriggeredSection: ( sectionSlug ) => {
+    onSetTriggeredSection: ( songSlug, sectionSlug ) => {
       dispatch(
         actions.setDeckTriggeredSection( {
           deckSlug: ownProps.slug,
+          songSlug,
           sectionSlug,
         } )
       );

--- a/src/apps/throwdown/components/throwdown/deck-row.jsx
+++ b/src/apps/throwdown/components/throwdown/deck-row.jsx
@@ -122,10 +122,11 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
       );
     },
 
-    onSetPartTriggeredSection: ( sectionSlug, partSlug, patternSlug ) => {
+    onSetPartTriggeredSection: ( songSlug, sectionSlug, partSlug, patternSlug ) => {
       dispatch(
         actions.setDeckSectionPartTriggeredPattern( {
           deckSlug: ownProps.slug,
+          songSlug: songSlug,
           partSlug,
           sectionSlug,
           patternSlug,

--- a/src/apps/throwdown/components/throwdown/reducer.js
+++ b/src/apps/throwdown/components/throwdown/reducer.js
@@ -29,7 +29,7 @@ function getSongPattern( state, songSlug, patternSlug ) {
     pattern => ( pattern.slug === patternSlug ) && ( pattern.songSlug === songSlug )
   );
 }
-function getDeckSectionPart( state, deckSlug, sectionSlug, songSlug, partSlug ) {
+function getDeckSectionPart( state, deckSlug, songSlug, sectionSlug, partSlug ) {
   const deck = getDeck( state, deckSlug );
   if ( ! deck ) { return; }
 

--- a/src/apps/throwdown/components/throwdown/reducer.js
+++ b/src/apps/throwdown/components/throwdown/reducer.js
@@ -8,8 +8,8 @@ function createDeck() {
   return {
     slug: '',
     hue: Math.random() * 360,
-    triggeredSection: null,
-    playingSection: null,
+    triggeredSection: null, // { song, section }
+    playingSection: null, // { song, section }
     sections: [],
   };
 }
@@ -29,19 +29,19 @@ function getSongPattern( state, songSlug, patternSlug ) {
     pattern => ( pattern.slug === patternSlug ) && ( pattern.songSlug === songSlug )
   );
 }
-function getDeckSectionPart( state, deckSlug, sectionSlug, partSlug ) {
+function getDeckSectionPart( state, deckSlug, sectionSlug, songSlug, partSlug ) {
   const deck = getDeck( state, deckSlug );
   if ( ! deck ) { return; }
 
-  const section = _.find( deck.sections, { slug: sectionSlug } );
+  const section = _.find( deck.sections, { slug: sectionSlug, songSlug } );
   if ( ! section ) { return; }
 
   return _.find( section.parts, { part: partSlug } );
 }
 
 const throwdownReducer = createReducer( {
-  audioContext: null,
-  buffers: [],
+  // audioContext: null,
+  // buffers: [],
 
   patterns: [],
 
@@ -135,8 +135,10 @@ const throwdownReducer = createReducer( {
     if ( ! deck ) return;
 
     // pass no slug to clear triggered section
-    deck.triggeredSection = action.payload.sectionSlug;
-    deck.triggeredSong = action.payload.songSlug;
+    deck.triggeredSection = {
+      section: action.payload.sectionSlug,
+      song: action.payload.songSlug,
+    };
   },
   [actions.toggleDeckTriggeredSection]: ( state, action ) => {
     const deck = state.decks[action.payload.deckIndex];
@@ -144,11 +146,15 @@ const throwdownReducer = createReducer( {
 
     const section = deck.sections[action.payload.sectionIndex];
     const sectionSlug = section ? section.slug : '';
-    if ( deck.triggeredSection !== sectionSlug ) {
-      deck.triggeredSection = sectionSlug;
+    const songSlug = section ? section.songSlug : '';
+    if ( ( deck.triggeredSection.section === sectionSlug ) && ( deck.triggeredSection.song === songSlug ) ) {
+      deck.triggeredSection = null;
     }
     else {
-      deck.triggeredSection = null;
+      deck.triggeredSection = {
+        song: songSlug,
+        section: sectionSlug,
+      };
     }
   },
 
@@ -156,8 +162,11 @@ const throwdownReducer = createReducer( {
     const deck = getDeck( state, action.payload.deckSlug );
     if ( !deck ) return;
 
-    // pass no slug to clear playing section
-    deck.playingSection = action.payload.sectionSlug;
+    // pass {} to clear playing section
+    deck.playingSection = {
+      song: action.payload.songSlug,
+      section: action.payload.sectionSlug,
+    };
   },
 
   [actions.setDeckPatternPlaystate]: ( state, action ) => {
@@ -175,6 +184,7 @@ const throwdownReducer = createReducer( {
     const part = getDeckSectionPart(
       state,
       action.payload.deckSlug,
+      action.payload.songSlug,
       action.payload.sectionSlug,
       action.payload.partSlug
     );

--- a/src/apps/throwdown/components/throwdown/reducer.js
+++ b/src/apps/throwdown/components/throwdown/reducer.js
@@ -94,7 +94,7 @@ const throwdownReducer = createReducer( {
 
     // get a list of full pattern data for the patterns in this section (i.e. filter out others)
     const sectionPatternData = _.filter( state.patterns, ( data ) => {
-      const sameSong = ( data.songSlug === action.payload.deckSlug );
+      const sameSong = ( data.songSlug === action.payload.songSlug );
       const inThisSection = ( _.indexOf( patternsInSection, data.slug ) !== -1 );
       return sameSong && inThisSection;
     } );
@@ -105,7 +105,7 @@ const throwdownReducer = createReducer( {
     // generate state array for patterns x parts (instruments)
     const partsPatterns = _.map( sectionPartSlugs, partSlug => {
       const patternData = _.filter( state.patterns, ( pattern, slug ) => {
-        const songMatch = ( pattern.songSlug === action.payload.deckSlug );
+        const songMatch = ( pattern.songSlug === action.payload.songSlug );
         const partMatch = ( pattern.part === partSlug );
         const sectionMatch = _.includes( patternsInSection, pattern.slug );
         return songMatch && partMatch && sectionMatch;
@@ -123,6 +123,7 @@ const throwdownReducer = createReducer( {
 
     deck.sections.push( {
       slug: action.payload.slug,
+      songSlug: action.payload.songSlug,
       duration: action.payload.bars * 4,
       patterns: action.payload.patterns,
       parts: partsPatterns,
@@ -135,6 +136,7 @@ const throwdownReducer = createReducer( {
 
     // pass no slug to clear triggered section
     deck.triggeredSection = action.payload.sectionSlug;
+    deck.triggeredSong = action.payload.songSlug;
   },
   [actions.toggleDeckTriggeredSection]: ( state, action ) => {
     const deck = state.decks[action.payload.deckIndex];

--- a/src/apps/throwdown/components/throwdown/section-player.js
+++ b/src/apps/throwdown/components/throwdown/section-player.js
@@ -45,7 +45,7 @@ class SectionPlayer {
       renderRangeBeats,
       this.props.triggered,
       this.props.playing,
-      this.props.triggerLoop,
+      this.props.triggerLoop
       // start beats and end beats for section .. is that a thing??
     );
 

--- a/src/apps/throwdown/components/throwdown/section.jsx
+++ b/src/apps/throwdown/components/throwdown/section.jsx
@@ -61,7 +61,7 @@ function SectionTrigger( props ) {
 
   const parts = props.parts.map( part => {
     const partProps = {
-      onSetPartTriggeredSection: props.onSetPartTriggeredSection.bind( null, sectionSlug ),
+      onSetPartTriggeredSection: props.onSetPartTriggeredSection.bind( null, props.songSlug, sectionSlug ),
       playingPatterns: playingPatternSlugs,
       ...part,
     };

--- a/src/apps/throwdown/components/throwdown/section.jsx
+++ b/src/apps/throwdown/components/throwdown/section.jsx
@@ -16,11 +16,11 @@ function PartTriggers( props ) {
       <div className='part-slug'>{ props.part }</div>
       {
         props.patterns.map( patternSlug => {
-          const patternIsPlaying = ( _.indexOf( props.playingPatterns, patternSlug ) !== -1 );
+          const patternNameIsPlaying = ( _.indexOf( props.playingPatterns, patternSlug ) !== -1 );
           const patternIsTriggered = ( patternSlug === props.triggeredPattern );
           const patternStyles = triggerStyling(
             patternIsTriggered,
-            patternIsPlaying
+            ( patternNameIsPlaying && props.songIsPlaying )
           );
           return (
             <div
@@ -41,6 +41,7 @@ function PartTriggers( props ) {
 }
 
 PartTriggers.propTypes = {
+  songIsPlaying: PropTypes.bool,
   part: PropTypes.string,
   patterns: PropTypes.array,
   triggeredPattern: PropTypes.string,
@@ -63,6 +64,7 @@ function SectionTrigger( props ) {
     const partProps = {
       onSetPartTriggeredSection: props.onSetPartTriggeredSection.bind( null, props.songSlug, sectionSlug ),
       playingPatterns: playingPatternSlugs,
+      songIsPlaying: ( props.songSlug === props.playingSong ),
       ...part,
     };
     return PartTriggers( partProps );
@@ -84,6 +86,8 @@ function SectionTrigger( props ) {
 }
 
 SectionTrigger.propTypes = {
+  playingSong: PropTypes.string,
+  playingSection: PropTypes.string,
   playing: PropTypes.bool,
   triggered: PropTypes.bool,
   onSetTriggeredSection: PropTypes.func,

--- a/src/apps/throwdown/components/throwdown/section.jsx
+++ b/src/apps/throwdown/components/throwdown/section.jsx
@@ -53,6 +53,7 @@ function SectionTrigger( props ) {
   const styles = triggerStyling( props.triggered, props.playing );
   const toggleTrigger = props.onSetTriggeredSection.bind(
     null,
+    props.triggered ? null : props.songSlug,
     props.triggered ? null : props.slug
   );
 
@@ -73,7 +74,7 @@ function SectionTrigger( props ) {
         style={ styles }
         className='section'
       >
-        { props.slug }
+        { props.songSlug } { props.slug }
       </div>
       <div className='parts'>
         { parts }
@@ -87,6 +88,7 @@ SectionTrigger.propTypes = {
   triggered: PropTypes.bool,
   onSetTriggeredSection: PropTypes.func,
   onSetPartTriggeredSection: PropTypes.func,
+  songSlug: PropTypes.string,
   slug: PropTypes.string,
   hue: PropTypes.number,
   parts: PropTypes.array,

--- a/src/apps/throwdown/components/throwdown/selectors.js
+++ b/src/apps/throwdown/components/throwdown/selectors.js
@@ -94,7 +94,7 @@ function getAllDeckPatterns( state, deckSlug ) {
     var patterns = section.patterns.map(
       patternSlug => _.find( allPatterns, {
         slug: patternSlug,
-        songSlug: deckState.slug,
+        songSlug: section.songSlug,
       } )
     );
     return _.filter( patterns ); // filter out undefined patterns, e.g. slug not present

--- a/src/apps/throwdown/get-channel-for-part.js
+++ b/src/apps/throwdown/get-channel-for-part.js
@@ -71,9 +71,15 @@ const getChannelForPart = function( partName ) {
   if ( _.isNumber( channel ) ) {
     return channel;
   }
-  else {
-    return 1;
+
+  const partialMatch = _.findKey( channelConventionsFourChannels, ( channel, part ) => {
+    return partName.startsWith( part );
+  } );
+  if ( partialMatch ) {
+    return channelConventionsFourChannels[partialMatch];
   }
+
+  return 1;
 };
 
 export default getChannelForPart;

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -36,29 +36,22 @@ store.dispatch( throwdownActions.addDeck( {
   deckSlug: 'B2',
 } ) );
 
-// fileImport.importThrowdownFile( 'data/20190325--mivova.hjson' );
+fileImport.importThrowdownFileToDeck( 'data/20190325--mivova.hjson', 'A1' );
 fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'A1' );
+fileImport.importThrowdownFileToDeck( 'data/20190325--kufca.hjson', 'A1' );
+
+fileImport.importThrowdownFileToDeck( 'data/20190325--noyu.hjson', 'B2' );
+fileImport.importThrowdownFileToDeck( 'data/20190325--maenyb.hjson', 'B2' );
+fileImport.importThrowdownFileToDeck( 'data/20190306--sweets-from-a-stranger.hjson', 'B2' );
 fileImport.importThrowdownFileToDeck( 'data/20190217--manas.hjson', 'B2' );
-// fileImport.importThrowdownFile( 'data/20190325--kufca.hjson' );
-// fileImport.importThrowdownFile( 'data/20190325--maenyb.hjson' );
+
 // fileImport.importThrowdownFile( 'data/20190422--likeso.hjson' );
 // fileImport.importThrowdownFile( 'data/nook-cranny/20190325--ambients.hjson' );
 // fileImport.importThrowdownFile( 'data/nook-cranny/20190325--beats.hjson' );
 // fileImport.importThrowdownFile( 'data/nook-cranny/20190325--transitions.hjson' );
-// fileImport.importThrowdownFile( 'data/20190306--sweets-from-a-stranger.hjson' );
 // fileImport.importThrowdownFile( 'data/20190422--squelch.hjson' );
 // fileImport.importThrowdownFile( 'data/20190422--breakfast.hjson' );
-// fileImport.importThrowdownFile( 'data/20190412--the-jacket.hjson' );
-// fileImport.importThrowdownFile( '/data/20190325--noyu.hjson' );
-// fileImport.importThrowdownFile( '/data/20190325--alex-haszard-bdmt.hjson' );
-// fileImport.importThrowdownFile( '/data/20190217--manas.hjson' );
-// importThrowdownFile( '/data/20190325--noyu.hjson' );
-// importThrowdownFile( '/data/20190325--alex-haszard-bdmt.hjson' );
-// importThrowdownFile( 'data/20190306--sweets-from-a-stranger.hjson' );
-// importThrowdownFile( 'data/20190325--maenyb.hjson' );
-// importThrowdownFile( 'data/20190325--shedout.hjson' );
-// importThrowdownFile( 'data/20190325--mivova.hjson' );
-// fileImport.importThrowdownFile( 'data/20190325--kufca.hjson' );
+// fileImport.importThrowdownFile( 'data/20190325--alex-haszard-bdmt.hjson' );
 
 const initialTempo = 128;
 store.dispatch(

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -13,6 +13,7 @@ import HeaderPlaybackProgress from './components/playback-progress/header-progre
 import Decks from './components/throwdown/decks.jsx';
 
 import transportActions from './components/transport/actions';
+import throwdownActions from './components/throwdown/actions';
 
 import fileImport from './components/drag-drop/file-import';
 import importDrop from './components/drag-drop/ghost-deck.jsx';
@@ -27,9 +28,17 @@ const throwdownApp = new ThrowdownApp();
 /// -----------------------------------------------------------------------------------------------
 // load hard-coded test data
 
+store.dispatch( throwdownActions.addDeck( {
+  deckSlug: 'A1',
+} ) );
+
+store.dispatch( throwdownActions.addDeck( {
+  deckSlug: 'B2',
+} ) );
+
 // fileImport.importThrowdownFile( 'data/20190325--mivova.hjson' );
-fileImport.importThrowdownFile( 'data/20191116--jacket.hjson' );
-// fileImport.importThrowdownFile( 'data/20190217--manas.hjson' );
+fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'A1' );
+fileImport.importThrowdownFileToDeck( 'data/20190217--manas.hjson', 'B2' );
 // fileImport.importThrowdownFile( 'data/20190325--kufca.hjson' );
 // fileImport.importThrowdownFile( 'data/20190325--maenyb.hjson' );
 // fileImport.importThrowdownFile( 'data/20190422--likeso.hjson' );

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -36,6 +36,7 @@ store.dispatch( throwdownActions.addDeck( {
   deckSlug: 'B2',
 } ) );
 
+fileImport.importThrowdownFileToDeck( 'data/20190325--shedout.hjson', 'A1' );
 fileImport.importThrowdownFileToDeck( 'data/20190325--mivova.hjson', 'A1' );
 fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'A1' );
 fileImport.importThrowdownFileToDeck( 'data/20190325--kufca.hjson', 'A1' );

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -27,9 +27,10 @@ const throwdownApp = new ThrowdownApp();
 /// -----------------------------------------------------------------------------------------------
 // load hard-coded test data
 
-fileImport.importThrowdownFile( 'data/20190325--mivova.hjson' );
-fileImport.importThrowdownFile( 'data/20190217--manas.hjson' );
-fileImport.importThrowdownFile( 'data/20190325--kufca.hjson' );
+// fileImport.importThrowdownFile( 'data/20190325--mivova.hjson' );
+fileImport.importThrowdownFile( 'data/20191116--jacket.hjson' );
+// fileImport.importThrowdownFile( 'data/20190217--manas.hjson' );
+// fileImport.importThrowdownFile( 'data/20190325--kufca.hjson' );
 // fileImport.importThrowdownFile( 'data/20190325--maenyb.hjson' );
 // fileImport.importThrowdownFile( 'data/20190422--likeso.hjson' );
 // fileImport.importThrowdownFile( 'data/nook-cranny/20190325--ambients.hjson' );
@@ -50,7 +51,7 @@ fileImport.importThrowdownFile( 'data/20190325--kufca.hjson' );
 // importThrowdownFile( 'data/20190325--mivova.hjson' );
 // fileImport.importThrowdownFile( 'data/20190325--kufca.hjson' );
 
-const initialTempo = 131;
+const initialTempo = 128;
 store.dispatch(
   transportActions.setTempo( initialTempo )
 );

--- a/src/apps/throwdown/throwdown-app.js
+++ b/src/apps/throwdown/throwdown-app.js
@@ -116,7 +116,8 @@ class ThrowdownApp {
     _.map( this.deckPlayers, deckPlayer => {
       store.dispatch( throwdownActions.setDeckPlayingSection( {
         deckSlug: deckPlayer.props.slug,
-        sectionSlug: deckPlayer.props.playingSection,
+        songSlug: deckPlayer.props.playingSection ? deckPlayer.props.playingSection.song : null,
+        sectionSlug: deckPlayer.props.playingSection ? deckPlayer.props.playingSection.section : null,
       } ) );
     } );
   }

--- a/src/data/20190217--manas.hjson
+++ b/src/data/20190217--manas.hjson
@@ -21,7 +21,7 @@
       file: '/media/Haszari/Haszari%20Renders%20-%20Snips%20Stems%20Padded%20Landscape/20170709-padscape--manas-voc-hills.m4a'
       tempo: 132,
       duration: 32
-      startBeats: [ -4 ] 
+      startBeats: [ -4, 0 ] 
     }
     sub: {
       part: sub

--- a/src/data/20190306--sweets-from-a-stranger.hjson
+++ b/src/data/20190306--sweets-from-a-stranger.hjson
@@ -34,8 +34,7 @@
     }
   }
   sections: {
-    main: {
-      bars: 4
+    a: {
       patterns: [
         beatr
         subr
@@ -43,20 +42,13 @@
         stabr
       ]
     }
-    beat: {
-      bars: 4
+    b: {
       patterns: [
         beatr
-        stabr
-      ]
-    }
-    melo: {
-      bars: 4
-      patterns: [
         subr
         leadr
         stabr
       ]
     }
-  } 
+  }
 }

--- a/src/data/20190325--maenyb.hjson
+++ b/src/data/20190325--maenyb.hjson
@@ -28,29 +28,7 @@
     }
   }
   sections: {
-    intro: {
-      bars: 4
-      patterns: [
-        beat
-        chords
-      ]
-    }
-    break: {
-      bars: 4
-      patterns: [
-        chords
-        lead
-      ]
-    }
-    drumbass: {
-      bars: 4
-      patterns: [
-        beat
-        sub
-      ]
-    }
-    main: {
-      bars: 4
+    a: {
       patterns: [
         beat
         sub
@@ -58,10 +36,11 @@
         lead
       ]
     }
-    outro: {
-      bars: 4
+    b: {
       patterns: [
         beat
+        sub
+        chords
         lead
       ]
     }

--- a/src/data/20190325--noyu.hjson
+++ b/src/data/20190325--noyu.hjson
@@ -30,22 +30,15 @@
     }
   }
   sections: {
-    intro: {
-      bars: 4
+    a: {
       patterns: [
         beat
-        chords
-      ]
-    }
-    break: {
-      bars: 4
-      patterns: [
+        bass
         piano
         chords
       ]
     }
-    main: {
-      bars: 4
+    b: {
       patterns: [
         beat
         bass

--- a/src/data/20190325--shedout.hjson
+++ b/src/data/20190325--shedout.hjson
@@ -28,22 +28,15 @@
     }
   }
   sections: {
-    ambient: {
-      bars: 4
+    a: {
       patterns: [
+        beat
+        sub
         texture
         lead
       ]
     }
-    drumbass: {
-      bars: 4
-      patterns: [
-        beat
-        sub
-      ]
-    }
-    main: {
-      bars: 4
+    b: {
       patterns: [
         beat
         sub

--- a/src/data/20191116--jacket.hjson
+++ b/src/data/20191116--jacket.hjson
@@ -1,0 +1,49 @@
+{
+  version: 1
+  slug: jacket
+  patterns: {
+    beat: {
+      part: beat
+      file: '/media/Haszari/Haszari%20Renders%20-%20Stems/The%20Jacket%20-%20Drums.m4a'
+      offset: 7.507
+      tempo: 128
+      duration: 8
+    }
+    # sub: {
+    #   part: sub
+    #   file: '/media/Haszari/Haszari%20Renders%20-%20Snips%20Stems%20Padded%20Landscape/20170806-kufca-padscape-sub-ridge.mp3'
+    #   tempo: 126
+    #   duration: 16
+    # }
+    # lead: {
+    #   part: lead
+    #   file: '/media/Haszari/Haszari%20Renders%20-%20Snips%20Stems%20Padded%20Landscape/20170806-kufca-padscape-lead-uplands.mp3'
+    #   tempo: 126
+    #   duration: 64   
+    # }
+    # texture: {
+    #   part: texture
+    #   file: '/media/Haszari/Haszari%20Renders%20-%20Snips%20Stems%20Padded%20Landscape/20170806-kufca-padscape-texture-hills.mp3'
+    #   tempo: 126
+    #   duration: 64
+    # }
+  }
+  sections: {
+    a: {
+      patterns: [
+        beat
+        # sub
+        # texture
+        # lead
+      ]
+    }
+    # b: {
+    #   patterns: [
+    #     beat
+    #     sub
+    #     texture
+    #     lead
+    #   ]
+    # }
+  } 
+}

--- a/src/data/20191116--jacket.hjson
+++ b/src/data/20191116--jacket.hjson
@@ -3,14 +3,14 @@
   slug: jacket
   patterns: {
     beat: {
-      part: drums
+      part: beat
       file: '/media/Haszari/Haszari%20Renders%20-%20Stems/The%20Jacket%20-%20Drums.m4a'
       offset: 7.507
       tempo: 128
       duration: 8
     }
     hat: {
-      part: drums
+      part: hat
       file: '/media/Haszari/Haszari%20Renders%20-%20Stems/The%20Jacket%20-%20HiHats.m4a'
       offset: 7.507
       tempo: 128

--- a/src/data/20191116--jacket.hjson
+++ b/src/data/20191116--jacket.hjson
@@ -74,13 +74,15 @@
         pad
       ]
     }
-    # b: {
-    #   patterns: [
-    #     beat
-    #     sub
-    #     texture
-    #     lead
-    #   ]
-    # }
+    b: {
+      patterns: [
+        beat
+        hat
+        sub
+        bass
+        tabla
+        pad
+      ]
+    }
   } 
 }

--- a/src/data/20191116--jacket.hjson
+++ b/src/data/20191116--jacket.hjson
@@ -3,11 +3,46 @@
   slug: jacket
   patterns: {
     beat: {
-      part: beat
+      part: drums
       file: '/media/Haszari/Haszari%20Renders%20-%20Stems/The%20Jacket%20-%20Drums.m4a'
       offset: 7.507
       tempo: 128
       duration: 8
+    }
+    hat: {
+      part: drums
+      file: '/media/Haszari/Haszari%20Renders%20-%20Stems/The%20Jacket%20-%20HiHats.m4a'
+      offset: 7.507
+      tempo: 128
+      duration: 8
+    }
+    sub: {
+      part: sub
+      file: '/media/Haszari/Haszari%20Renders%20-%20Stems/The%20Jacket%20-%20Sub.m4a'
+      offset: 37.478
+      tempo: 128
+      duration: 32
+    }
+    bass: {
+      part: bass
+      file: '/media/Haszari/Haszari%20Renders%20-%20Stems/The%20Jacket%20-%20Bass.m4a'
+      offset: 82.495
+      tempo: 128
+      duration: 16
+    }
+    tabla: {
+      part: perc
+      file: '/media/Haszari/Haszari%20Renders%20-%20Stems/The%20Jacket%20-%20Tabla.m4a'
+      offset: 37.506
+      tempo: 128
+      duration: 8
+    }
+    pad: {
+      part: pad
+      file: '/media/Haszari/Haszari%20Renders%20-%20Stems/The%20Jacket%20-%20Pad.m4a'
+      offset: 37.506
+      tempo: 128
+      duration: 16
     }
     # sub: {
     #   part: sub
@@ -32,9 +67,11 @@
     a: {
       patterns: [
         beat
-        # sub
-        # texture
-        # lead
+        hat
+        sub
+        bass
+        tabla
+        pad
       ]
     }
     # b: {


### PR DESCRIPTION
Previously, all songs loaded into a deck specifically for that song. This PR allows songs to be loaded into an arbitrary deck. 

This allows the possibility of routing decks into different audio/midi outputs so patterns can be mixed live.