### PR TITLE
More robust handling of same song in different decks

### DIFF
--- a/src/apps/throwdown/components/drag-drop/file-import.js
+++ b/src/apps/throwdown/components/drag-drop/file-import.js
@@ -20,9 +20,10 @@ function ensureAudioBuffered( filename ) {
   } );
 }
 
-function importPatterns( songSlug, patterns ) {
+function importPatterns( deckSlug, songSlug, patterns ) {
   _.map( patterns, ( pattern, key ) => {
     store.dispatch( throwdownActions.addPattern( {
+      deckSlug,
       songSlug,
       slug: key,
       ...pattern,
@@ -46,36 +47,10 @@ function getUniqueImportSlug( slug, filename ) {
   return uniqueSlug;
 }
 
-function addThrowdownDeck( filename, throwdownData, replaceDeckRowSlug ) {
-  const songSlug = getUniqueImportSlug( throwdownData.slug, filename );
-
-  importPatterns( songSlug, throwdownData.patterns );
-
-  store.dispatch( throwdownActions.addDeck( {
-    deckSlug: songSlug,
-    replaceDeckSlug: replaceDeckRowSlug,
-  } ) );
-
-  _.map( throwdownData.sections, ( section, key ) => {
-    store.dispatch( throwdownActions.addSection( {
-      deckSlug: songSlug,
-      slug: key,
-      ...section,
-    } ) );
-  } );
-
-  return songSlug;
-}
-
 function addSectionsToDeck( filename, throwdownData, deckSlug ) {
   const songSlug = getUniqueImportSlug( throwdownData.slug, filename );
 
-  importPatterns( songSlug, throwdownData.patterns );
-
-  // store.dispatch( throwdownActions.addDeck( {
-  //   deckSlug: songSlug,
-  //   replaceDeckSlug: replaceDeckRowSlug,
-  // } ) );
+  importPatterns( deckSlug, songSlug, throwdownData.patterns );
 
   _.map( throwdownData.sections, ( section, key ) => {
     store.dispatch( throwdownActions.addSection( {
@@ -89,15 +64,6 @@ function addSectionsToDeck( filename, throwdownData, deckSlug ) {
   return deckSlug;
 }
 
-function importThrowdownFile( fileUrl ) {
-  window.fetch( fileUrl )
-    .then( response => response.text() )
-    .then( text => {
-      const songData = Hjson.parse( text );
-      addThrowdownDeck( fileUrl, songData );
-    } );
-}
-
 function importThrowdownFileToDeck( fileUrl, deckSlug ) {
   window.fetch( fileUrl )
     .then( response => response.text() )
@@ -107,12 +73,6 @@ function importThrowdownFileToDeck( fileUrl, deckSlug ) {
     } );
 }
 
-function importThrowdownData( filename, hjsonBlob, replaceDeckRowSlug ) {
-  addThrowdownDeck( filename, hjsonBlob, replaceDeckRowSlug );
-}
-
 export default {
-  importThrowdownFile,
-  importThrowdownData,
   importThrowdownFileToDeck,
 };

--- a/src/apps/throwdown/components/throwdown/deck-player.js
+++ b/src/apps/throwdown/components/throwdown/deck-player.js
@@ -196,6 +196,7 @@ class DeckPlayer {
 
         // console.log( `play ${ patternSlug } inTriggeredSection=${ isInTriggeredSection } isTriggered=${ isTriggered } was=${ wasPlaying } now=${ stillPlaying }` );
         patternPlayStates.push( {
+          deckSlug: this.props.slug,
           songSlug: player.songSlug,
           patternSlug: player.patternSlug,
           isPlaying: stillPlaying,

--- a/src/apps/throwdown/components/throwdown/selectors.js
+++ b/src/apps/throwdown/components/throwdown/selectors.js
@@ -93,6 +93,7 @@ function getAllDeckPatterns( state, deckSlug ) {
   const sectionPatterns = deckState.sections.map( section => {
     var patterns = section.patterns.map(
       patternSlug => _.find( allPatterns, {
+        deckSlug,
         slug: patternSlug,
         songSlug: section.songSlug,
       } )

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -37,14 +37,22 @@ store.dispatch( throwdownActions.addDeck( {
 } ) );
 
 fileImport.importThrowdownFileToDeck( 'data/20190325--shedout.hjson', 'A1' );
-fileImport.importThrowdownFileToDeck( 'data/20190325--mivova.hjson', 'A1' );
-fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'A1' );
-fileImport.importThrowdownFileToDeck( 'data/20190325--kufca.hjson', 'A1' );
+fileImport.importThrowdownFileToDeck( 'data/20190325--noyu.hjson', 'A1' );
+fileImport.importThrowdownFileToDeck( 'data/20190325--maenyb.hjson', 'A1' );
+fileImport.importThrowdownFileToDeck( 'data/20190217--manas.hjson', 'A1' );
+// fileImport.importThrowdownFileToDeck( 'data/20190325--mivova.hjson', 'A1' );
+// fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'A1' );
+// fileImport.importThrowdownFileToDeck( 'data/20190325--kufca.hjson', 'A1' );
+// fileImport.importThrowdownFileToDeck( 'data/20190306--sweets-from-a-stranger.hjson', 'A1' );
 
+fileImport.importThrowdownFileToDeck( 'data/20190325--shedout.hjson', 'B2' );
 fileImport.importThrowdownFileToDeck( 'data/20190325--noyu.hjson', 'B2' );
 fileImport.importThrowdownFileToDeck( 'data/20190325--maenyb.hjson', 'B2' );
-fileImport.importThrowdownFileToDeck( 'data/20190306--sweets-from-a-stranger.hjson', 'B2' );
 fileImport.importThrowdownFileToDeck( 'data/20190217--manas.hjson', 'B2' );
+// fileImport.importThrowdownFileToDeck( 'data/20190325--mivova.hjson', 'B2' );
+// fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'B2' );
+// fileImport.importThrowdownFileToDeck( 'data/20190325--kufca.hjson', 'B2' );
+// fileImport.importThrowdownFileToDeck( 'data/20190306--sweets-from-a-stranger.hjson', 'B2' );
 
 // fileImport.importThrowdownFile( 'data/20190422--likeso.hjson' );
 // fileImport.importThrowdownFile( 'data/nook-cranny/20190325--ambients.hjson' );


### PR DESCRIPTION
We don't yet support loading songs at runtime, or "dragging" songs between decks. Decks are used for routing out to mixer channels, so if you want to jam with a few hard-coded songs, it's handy to allow songs to be imported into both decks.

This is also more robust - we don't want to assume deck==song.

Also, importing a song more than once was not tested. This PR deduplicates patterns on import, so that the latest import always overwrites the existing patterns. Also imports now require you to choose the destination deck - there's no shortcut to load a song into a deck with the same name.