### PR TITLE
support routing decks to different banks of audio/midi channels

### DIFF
--- a/src/apps/throwdown/components/throwdown/deck-player.js
+++ b/src/apps/throwdown/components/throwdown/deck-player.js
@@ -49,7 +49,7 @@ class DeckPlayer {
       var patternPlayer = this.getPatternPlayer( pattern.songSlug, pattern.slug );
 
       if ( ! patternPlayer ) {
-        patternPlayer = playerFactory.playerFromFilePatternData( pattern, props.buffers );
+        patternPlayer = playerFactory.playerFromFilePatternData( pattern, props.buffers, props.deckIndex );
         patternPlayer.songSlug = pattern.songSlug;
         patternPlayer.patternSlug = pattern.slug;
         this.replacePatternPlayer( pattern.songSlug, pattern.slug, patternPlayer );
@@ -237,6 +237,7 @@ class DeckPlayer {
 
 DeckPlayer.defaultProps = {
   slug: '',
+  deckIndex: 0,
   patterns: [],
   sections: [],
   buffers: [],

--- a/src/apps/throwdown/components/throwdown/deck-player.js
+++ b/src/apps/throwdown/components/throwdown/deck-player.js
@@ -55,7 +55,7 @@ class DeckPlayer {
         this.replacePatternPlayer( pattern.songSlug, pattern.slug, patternPlayer );
       }
       else {
-        patternPlayer.updateProps( playerFactory.getPlayerProps( pattern, props.buffers ) );
+        patternPlayer.updateProps( playerFactory.getPlayerProps( pattern, props.buffers, props.deckIndex ) );
       }
 
       patternPlayer.setParentPhrase( props.triggerLoop );

--- a/src/apps/throwdown/get-channel-for-part.js
+++ b/src/apps/throwdown/get-channel-for-part.js
@@ -85,7 +85,7 @@ const getChannelForPart = function( partName ) {
 
 function getChannelForPartOnDeck( partName, deckIndex ) {
   const channel = getChannelForPart( partName );
-  return channel + deckIndex * channelsPerDeck;
+  return channel + ( deckIndex * channelsPerDeck );
 }
 
 export default {

--- a/src/apps/throwdown/get-channel-for-part.js
+++ b/src/apps/throwdown/get-channel-for-part.js
@@ -31,6 +31,7 @@ import _ from 'lodash';
 // };
 
 // we only have four pairs in Ableton Live Intro, so let's use them more carefully
+const channelsPerDeck = 4;
 const channelConventionsFourChannels = {
   // percussion of any kind
   drums: 0,
@@ -82,4 +83,12 @@ const getChannelForPart = function( partName ) {
   return 1;
 };
 
-export default getChannelForPart;
+function getChannelForPartOnDeck( partName, deckIndex ) {
+  const channel = getChannelForPart( partName );
+  return channel + deckIndex * channelsPerDeck;
+}
+
+export default {
+  getChannelForPart,
+  getChannelForPartOnDeck,
+};

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -40,11 +40,17 @@ fileImport.importThrowdownFileToDeck( 'data/20190325--shedout.hjson', 'A1' );
 fileImport.importThrowdownFileToDeck( 'data/20190325--mivova.hjson', 'A1' );
 fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'A1' );
 fileImport.importThrowdownFileToDeck( 'data/20190325--kufca.hjson', 'A1' );
+fileImport.importThrowdownFileToDeck( 'data/20190325--maenyb.hjson', 'A1' );
 
-fileImport.importThrowdownFileToDeck( 'data/20190325--noyu.hjson', 'B2' );
+fileImport.importThrowdownFileToDeck( 'data/20190325--shedout.hjson', 'B2' );
+fileImport.importThrowdownFileToDeck( 'data/20190325--mivova.hjson', 'B2' );
+fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'B2' );
+fileImport.importThrowdownFileToDeck( 'data/20190325--kufca.hjson', 'B2' );
 fileImport.importThrowdownFileToDeck( 'data/20190325--maenyb.hjson', 'B2' );
-fileImport.importThrowdownFileToDeck( 'data/20190306--sweets-from-a-stranger.hjson', 'B2' );
-fileImport.importThrowdownFileToDeck( 'data/20190217--manas.hjson', 'B2' );
+
+// fileImport.importThrowdownFileToDeck( 'data/20190325--noyu.hjson', 'B2' );
+// fileImport.importThrowdownFileToDeck( 'data/20190306--sweets-from-a-stranger.hjson', 'B2' );
+// fileImport.importThrowdownFileToDeck( 'data/20190217--manas.hjson', 'B2' );
 
 // fileImport.importThrowdownFile( 'data/20190422--likeso.hjson' );
 // fileImport.importThrowdownFile( 'data/nook-cranny/20190325--ambients.hjson' );

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -37,16 +37,16 @@ store.dispatch( throwdownActions.addDeck( {
 } ) );
 
 fileImport.importThrowdownFileToDeck( 'data/20190325--shedout.hjson', 'A1' );
-fileImport.importThrowdownFileToDeck( 'data/20190325--mivova.hjson', 'A1' );
-fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'A1' );
-fileImport.importThrowdownFileToDeck( 'data/20190325--kufca.hjson', 'A1' );
-fileImport.importThrowdownFileToDeck( 'data/20190325--maenyb.hjson', 'A1' );
+// fileImport.importThrowdownFileToDeck( 'data/20190325--mivova.hjson', 'A1' );
+// fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'A1' );
+// fileImport.importThrowdownFileToDeck( 'data/20190325--kufca.hjson', 'A1' );
+// fileImport.importThrowdownFileToDeck( 'data/20190325--maenyb.hjson', 'A1' );
 
 fileImport.importThrowdownFileToDeck( 'data/20190325--shedout.hjson', 'B2' );
-fileImport.importThrowdownFileToDeck( 'data/20190325--mivova.hjson', 'B2' );
-fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'B2' );
-fileImport.importThrowdownFileToDeck( 'data/20190325--kufca.hjson', 'B2' );
-fileImport.importThrowdownFileToDeck( 'data/20190325--maenyb.hjson', 'B2' );
+// fileImport.importThrowdownFileToDeck( 'data/20190325--mivova.hjson', 'B2' );
+// fileImport.importThrowdownFileToDeck( 'data/20191116--jacket.hjson', 'B2' );
+// fileImport.importThrowdownFileToDeck( 'data/20190325--kufca.hjson', 'B2' );
+// fileImport.importThrowdownFileToDeck( 'data/20190325--maenyb.hjson', 'B2' );
 
 // fileImport.importThrowdownFileToDeck( 'data/20190325--noyu.hjson', 'B2' );
 // fileImport.importThrowdownFileToDeck( 'data/20190306--sweets-from-a-stranger.hjson', 'B2' );

--- a/src/apps/throwdown/player-factory.js
+++ b/src/apps/throwdown/player-factory.js
@@ -1,12 +1,12 @@
 import _ from 'lodash';
 
-import getChannelForPart from './get-channel-for-part';
+import channelConventions from './get-channel-for-part';
 
 import MidiLoopPlayer from './components/midi-loop-player';
 import SampleSlicePlayer from './components/sample-slice-player';
 
-function getPlayerProps( patternData, buffers ) {
-  var channel = patternData.channel || getChannelForPart( patternData.part );
+function getPlayerProps( patternData, buffers, deckIndex ) {
+  var channel = patternData.channel || channelConventions.getChannelForPartOnDeck( patternData.part, deckIndex );
   if ( patternData.notes ) {
     return {
       channel: channel,
@@ -17,7 +17,6 @@ function getPlayerProps( patternData, buffers ) {
     };
   }
   if ( patternData.file ) {
-    // const channel = getChannelForPart( resource.part || key );
     const stateBuffer = _.find( buffers, { file: patternData.file } );
     if ( !stateBuffer ) {
       return null;
@@ -37,8 +36,8 @@ function getPlayerProps( patternData, buffers ) {
   return null;
 }
 
-function playerFromFilePatternData( patternData, buffers ) {
-  const props = getPlayerProps( patternData, buffers );
+function playerFromFilePatternData( patternData, buffers, deckIndex ) {
+  const props = getPlayerProps( patternData, buffers, deckIndex );
   if ( !props ) {
     return null;
   }

--- a/src/apps/throwdown/throwdown-app.js
+++ b/src/apps/throwdown/throwdown-app.js
@@ -83,12 +83,13 @@ class ThrowdownApp {
     const deckPlayers = this.deckPlayers;
 
     // { deckSlug: sectionSlug: sectionPlayer: }
-    _.map( allDecks, ( deckState ) => {
+    _.map( allDecks, ( deckState, index ) => {
       var patterns = throwdownSelectors.getAllDeckPatterns( state, deckState.slug );
       var sections = throwdownSelectors.getDeckSections( state, deckState.slug );
 
       const deckProps = {
         slug: deckState.slug,
+        deckIndex: index,
         buffers: allBuffers,
         patterns,
         sections,


### PR DESCRIPTION
Parts can get automatically routed to different mixer/midi channels based on part name (see `get-channel-for-part.js`), if there is a multi channel audio device in use.

This PR extends this so that each deck is allocated a new batch of 4 channels.