### PR TITLE
route each deck into two channels: perc and synth/music/melodic/lead

### DIFF
--- a/src/apps/throwdown/get-channel-for-part.js
+++ b/src/apps/throwdown/get-channel-for-part.js
@@ -1,83 +1,96 @@
 import _ from 'lodash';
 
-// const channelConventions_six_channels = {
-//   drums: 0,
-//   beat: 0,
-//   kick: 0,
-//   hat: 0,
-//   snare: 0,
-//   clap: 0,
-//   perc: 0,
+function getChannelConventions() {
+  // const channelConventionsFourChannels = {
+  //   // percussion of any kind
+  //   drums: 0,
+  //   beat: 0,
+  //   kick: 0,
+  //   hat: 0,
+  //   snare: 0,
+  //   clap: 0,
+  //   perc: 0,
 
-//   bass: 1,
-//   sub: 1,
+  //   // sub bass
+  //   bass: 1,
+  //   sub: 1,
 
-//   chords: 2,
-//   pad: 2,
+  //   // synth chords pad lead whatever
+  //   chords: 2,
 
-//   lead: 3,
-//   synth: 3,
-//   melody: 3,
-//   stab: 3,
-//   arp: 3,
-//   arpeggio: 3,
+  //   pad: 2,
 
-//   vocal: 4,
-//   voc: 4,
-//   sample: 4,
+  //   lead: 2,
+  //   synth: 2,
+  //   melody: 2,
+  //   stab: 2,
+  //   arp: 2,
+  //   arpeggio: 2,
 
-//   texture: 5,
-//   fx: 5,
-// };
+  //   // vocal sample texture other misc
+  //   vocal: 3,
+  //   voc: 3,
+  //   sample: 3,
+  //   texture: 3,
+  //   fx: 3,
+  // };
 
-// we only have four pairs in Ableton Live Intro, so let's use them more carefully
-const channelsPerDeck = 4;
-const channelConventionsFourChannels = {
-  // percussion of any kind
-  drums: 0,
-  beat: 0,
-  kick: 0,
-  hat: 0,
-  snare: 0,
-  clap: 0,
-  perc: 0,
+  const channelConventionsTwoChannels = {
+    // percussion of any kind
+    drums: 0,
+    beat: 0,
+    kick: 0,
+    hat: 0,
+    snare: 0,
+    clap: 0,
+    perc: 0,
 
-  // sub bass
-  bass: 1,
-  sub: 1,
+    // sub bass
+    bass: 1,
+    sub: 1,
 
-  // synth chords pad lead whatever
-  chords: 2,
+    // synth chords pad lead whatever
+    chords: 1,
 
-  pad: 2,
+    pad: 1,
 
-  lead: 2,
-  synth: 2,
-  melody: 2,
-  stab: 2,
-  arp: 2,
-  arpeggio: 2,
+    lead: 1,
+    synth: 1,
+    melody: 1,
+    stab: 1,
+    arp: 1,
+    arpeggio: 1,
 
-  // vocal sample texture other misc
-  vocal: 3,
-  voc: 3,
-  sample: 3,
-  texture: 3,
-  fx: 3,
-};
+    // vocal sample texture other misc
+    vocal: 1,
+    voc: 1,
+    sample: 1,
+    texture: 1,
+    fx: 1,
+  };
+
+  return channelConventionsTwoChannels;
+}
+
+function getChannelsPerDeck() {
+  const channelMap = getChannelConventions();
+  return _.reduce( channelMap, ( result, value ) => {
+    return Math.max( result, value );
+  }, 0 ) + 1;
+}
 
 const getChannelForPart = function( partName ) {
   // conventions for midi instruments or mixer channels
-  const channel = channelConventionsFourChannels[partName];
+  const channel = getChannelConventions()[partName];
   if ( _.isNumber( channel ) ) {
     return channel;
   }
 
-  const partialMatch = _.findKey( channelConventionsFourChannels, ( channel, part ) => {
+  const partialMatch = _.findKey( getChannelConventions(), ( channel, part ) => {
     return partName.startsWith( part );
   } );
   if ( partialMatch ) {
-    return channelConventionsFourChannels[partialMatch];
+    return getChannelConventions()[partialMatch];
   }
 
   return 1;
@@ -85,7 +98,7 @@ const getChannelForPart = function( partName ) {
 
 function getChannelForPartOnDeck( partName, deckIndex ) {
   const channel = getChannelForPart( partName );
-  return channel + ( deckIndex * channelsPerDeck );
+  return channel + ( deckIndex * getChannelsPerDeck() );
 }
 
 export default {


### PR DESCRIPTION
Currently testing using Ableton Live Intro which has a max of 8 audio input channels. If we want to mix two songs, use stereo, then we have 4 channels total, 2 per deck a/b. This PR updates part => channel conventions so we only use 2 channels per deck. 

Also generates `channelsPerDeck` automatically instead of hard-coding it.