### PR TITLE
Add/support loop slice events

### DIFF
--- a/src/apps/throwdown/components/sample-slice-player.js
+++ b/src/apps/throwdown/components/sample-slice-player.js
@@ -113,10 +113,9 @@ class SampleSlicePlayer {
     this.player = player;
   }
 
-  stopPlaybackAt( stopTimestamp ) {
+  stopCurrentNoteAt( stopTimestamp ) {
     if ( this.player ) {
       this.player.stop( stopTimestamp );
-      this.playing = false;
       this.player = null;
     }
   }
@@ -176,7 +175,7 @@ class SampleSlicePlayer {
       const startTime = renderEventTime( sliceRenderInfo.start );
 
       // stop any current slice
-      this.stopPlaybackAt( startTime );
+      this.stopCurrentNoteAt( startTime );
 
       // If this slice has a duration, calculate stop timestamp.
       const stopTime = _.isUndefined( sliceRenderInfo.duration ) ? undefined : renderEventTime( sliceRenderInfo.start + sliceRenderInfo.duration );

--- a/src/apps/throwdown/components/sample-slice-player.js
+++ b/src/apps/throwdown/components/sample-slice-player.js
@@ -5,6 +5,19 @@ import audioUtilities from '@kytaime/audio-utilities';
 import bpmUtilities from '@kytaime/sequencer/bpm-utilities';
 import patternSequencer from '@kytaime/sequencer/pattern-sequencer';
 
+function getSliceCuts( startBeats, endBeats, duration ) {
+  // Start and end beats may be negative - wrap to length
+  startBeats = _.map( startBeats, beatValue => patternSequencer.modulus( beatValue, duration ) );
+  endBeats = _.map( endBeats, beatValue => patternSequencer.modulus( beatValue, duration ) );
+
+  var cuts = [ 0, startBeats, endBeats, duration ];
+  cuts = _.flatten( cuts );
+  cuts = _.sortBy( cuts );
+  cuts = _.sortedUniq( cuts );
+
+  return cuts;
+}
+
 function autogenerateSlices( startBeats, endBeats, duration ) {
   // We used to generate one slice for whole thing ...
   // this.props.slices = [{
@@ -19,13 +32,7 @@ function autogenerateSlices( startBeats, endBeats, duration ) {
   // to ensure that the slices support the ends/starts they have set :)
   var slices = [];
 
-  // Start and end beats may be negative - wrap to length
-  startBeats = _.map( startBeats, beatValue => patternSequencer.modulus( beatValue, duration ) );
-  endBeats = _.map( endBeats, beatValue => patternSequencer.modulus( beatValue, duration ) );
-  var cuts = [ 0, startBeats, endBeats, duration ];
-  cuts = _.flatten( cuts );
-  cuts = _.sortBy( cuts );
-  cuts = _.sortedUniq( cuts );
+  const cuts = getSliceCuts( startBeats, endBeats, duration );
 
   for ( var i = 1; i < cuts.length; i++ ) {
     const slice = {
@@ -57,6 +64,19 @@ class SampleSlicePlayer {
 
     if ( !this.props.slices || !this.props.slices.length ) {
       this.props.slices = autogenerateSlices( this.props.startBeats, this.props.endBeats, this.props.sampleDuration );
+    }
+
+    // generate a default duration for each note in case it's not specified
+    // (common with looping notes)
+    const { slices, sampleDuration } = this.props;
+    let curEndBeat = sampleDuration;
+    for ( let i = this.props.slices.length; i--; i >= 0 ) {
+      if ( _.isUndefined( slices[i].duration ) ) {
+        const duration = curEndBeat - slices[i].start;
+        slices[i].duration = duration;
+      }
+
+      curEndBeat = slices[i].start;
     }
   }
 
@@ -104,11 +124,7 @@ class SampleSlicePlayer {
 
     player.start( startTimestamp, sliceStart );
 
-    // Stopping is optional - if not specified, note will play until cut by another note
-    // or the pattern/transport stops this player.
-    if ( stopTimestamp ) {
-      player.stop( stopTimestamp );
-    }
+    player.stop( stopTimestamp );
 
     this.player = player;
   }
@@ -178,7 +194,8 @@ class SampleSlicePlayer {
       this.stopCurrentNoteAt( startTime );
 
       // If this slice has a duration, calculate stop timestamp.
-      const stopTime = _.isUndefined( sliceRenderInfo.duration ) ? undefined : renderEventTime( sliceRenderInfo.start + sliceRenderInfo.duration );
+      const stopBeat = sliceRenderInfo.start + sliceRenderInfo.duration;
+      const stopTime = renderEventTime( stopBeat );
 
       this.playSliceAt( startTime, stopTime, sliceRenderInfo.event.beat, sliceRenderInfo.event.loop, tempoBpm, renderRange.audioContext.destination );
     } );

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -103,7 +103,7 @@ routingConfig.audioPartMap = {
 var deckIndex = 0;
 
 store.dispatch( throwdownActions.addDeck( {
-  deckSlug: 'A1',
+  deckSlug: 'paknsave',
   routing: {
     firstAudioChannel: routingConfig.numAudioChannels * deckIndex, // aka 0
     firstMidiChannel: routingConfig.numMidiChannels * deckIndex, // aka 0
@@ -112,19 +112,10 @@ store.dispatch( throwdownActions.addDeck( {
 } ) );
 deckIndex++;
 
-store.dispatch( throwdownActions.addDeck( {
-  deckSlug: 'B2',
-  routing: {
-    firstAudioChannel: routingConfig.numAudioChannels * deckIndex,
-    firstMidiChannel: routingConfig.numMidiChannels * deckIndex,
-    ...routingConfig,
-  },
-} ) );
-
 /// -----------------------------------------------------------------------------------------------
 // load hard-coded test data
 
-fileImport.importThrowdownFileToDeck( 'data/20191125--janura-crossing.hjson', 'A1' );
+fileImport.importThrowdownFileToDeck( 'data/edits/20200106--tesko-suicide-pak-n-save.hjson', 'paknsave' );
 
 // fileImport.importThrowdownFileToDeck( 'data/20190325--noyu.hjson', 'A1' );
 // fileImport.importThrowdownFileToDeck( 'data/20190325--maenyb.hjson', 'A1' );
@@ -151,7 +142,7 @@ fileImport.importThrowdownFileToDeck( 'data/20191125--janura-crossing.hjson', 'A
 // fileImport.importThrowdownFile( 'data/20190422--breakfast.hjson' );
 // fileImport.importThrowdownFile( 'data/20190325--alex-haszard-bdmt.hjson' );
 
-const initialTempo = 120;
+const initialTempo = 135;
 store.dispatch(
   transportActions.setTempo( initialTempo )
 );

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -115,8 +115,8 @@ deckIndex++;
 /// -----------------------------------------------------------------------------------------------
 // load hard-coded test data
 
-// fileImport.importThrowdownFileToDeck( 'data/edits/20200106--tesko-suicide-pak-n-save.hjson', 'paknsave' );
-fileImport.importThrowdownFileToDeck( 'data/20190217--manas.hjson', 'paknsave' );
+fileImport.importThrowdownFileToDeck( 'data/edits/20200106--tesko-suicide-pak-n-save.hjson', 'paknsave' );
+// fileImport.importThrowdownFileToDeck( 'data/20190217--manas.hjson', 'paknsave' );
 
 // fileImport.importThrowdownFileToDeck( 'data/20191125--janura-crossing.hjson', 'A1' );
 // fileImport.importThrowdownFileToDeck( 'data/20190325--noyu.hjson', 'A1' );

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -115,8 +115,10 @@ deckIndex++;
 /// -----------------------------------------------------------------------------------------------
 // load hard-coded test data
 
-fileImport.importThrowdownFileToDeck( 'data/edits/20200106--tesko-suicide-pak-n-save.hjson', 'paknsave' );
+// fileImport.importThrowdownFileToDeck( 'data/edits/20200106--tesko-suicide-pak-n-save.hjson', 'paknsave' );
+fileImport.importThrowdownFileToDeck( 'data/20190217--manas.hjson', 'paknsave' );
 
+// fileImport.importThrowdownFileToDeck( 'data/20191125--janura-crossing.hjson', 'A1' );
 // fileImport.importThrowdownFileToDeck( 'data/20190325--noyu.hjson', 'A1' );
 // fileImport.importThrowdownFileToDeck( 'data/20190325--maenyb.hjson', 'A1' );
 // fileImport.importThrowdownFileToDeck( 'data/20190217--manas.hjson', 'A1' );

--- a/src/apps/throwdown/player-factory.js
+++ b/src/apps/throwdown/player-factory.js
@@ -27,7 +27,10 @@ function getPlayerProps( patternData, buffers, channel ) {
       sampleDuration: patternData.duration,
       startBeats: patternData.startBeats,
       endBeats: patternData.endBeats,
-      slices: patternData.slices,
+
+      // We clone this because we may want to fill in missing slice details like duration.
+      // If we don't clone it, the object is not extensible.
+      slices: _.cloneDeep( patternData.slices ),
     };
   }
   return null;

--- a/src/data/edits/20200106--tesko-suicide-pak-n-save.hjson
+++ b/src/data/edits/20200106--tesko-suicide-pak-n-save.hjson
@@ -1,0 +1,67 @@
+{
+  version: 1
+  slug: tesko
+  patterns: {
+    a: {
+      part: track
+      file: "/media/Sneaker Pimps/Becoming X/02 Tesko Suicide.m4a"
+      tempo: 135.1240 
+      duration: 32
+      offset: 2.733
+      slices: [
+        {
+          start: 0
+          // breakdown first 8 - beat
+          beat: 324
+          duration: 8    
+        }
+        {
+          start: 8
+          // breakdown first 8 - beat
+          beat: 324
+          duration: 8    
+        }
+        {
+          start: 16
+          // breakdown first 8 - beat
+          beat: 324
+          duration: 8    
+        }
+        {
+          start: 24
+          // breakdown last 8 - beat with glitch fill
+          beat: 332
+          duration: 8    
+        }
+      ]
+    }
+    b: {
+      part: track
+      file: "/media/Sneaker Pimps/Becoming X/02 Tesko Suicide.m4a"
+      tempo: 135.1240 
+      duration: 32
+      offset: 2.733
+      slices: [
+        {
+          start: 0
+          // intro first 32
+          beat: 0
+          duration: 32    
+        }
+        // more to come
+      ]
+    }
+  }
+  sections: {
+    a: {
+      patterns: [
+        a
+      ]
+    }
+    b: {
+      patterns: [
+        b
+      ]
+    }
+  } 
+}

--- a/src/data/edits/20200106--tesko-suicide-pak-n-save.hjson
+++ b/src/data/edits/20200106--tesko-suicide-pak-n-save.hjson
@@ -13,25 +13,25 @@
           start: 0
           // breakdown first 8 - beat
           beat: 324
-          duration: 8    
+          loop: 8
         }
-        {
-          start: 8
-          // breakdown first 8 - beat
-          beat: 324
-          duration: 8    
-        }
-        {
-          start: 16
-          // breakdown first 8 - beat
-          beat: 324
-          duration: 8    
-        }
+        # {
+        #   start: 8
+        #   duration: 8    
+        #   // breakdown first 8 - beat
+        #   beat: 324
+        # }
+        # {
+        #   start: 16
+        #   duration: 8    
+        #   // breakdown first 8 - beat
+        #   beat: 324
+        # }
         {
           start: 24
+          duration: 8    
           // breakdown last 8 - beat with glitch fill
           beat: 332
-          duration: 8    
         }
       ]
     }
@@ -44,11 +44,20 @@
       slices: [
         {
           start: 0
+          loop: 32    
           // intro first 32
           beat: 0
-          duration: 32    
         }
-        // more to come
+      ]
+      variation: [
+        { 
+          // mute all playback
+          type: mute
+          // every second pattern repeat
+          every: 2
+          // starting at -4 beat, i.e mute last bar of end of previous cycle
+          start: -6
+        }
       ]
     }
   }


### PR DESCRIPTION
Adds support for audio slice events to loop a section of audio. 

- In the hjson data use `loop` key on an event to specify the loop length for that note. 
- If a `duration` is specified, the note will loop for that length of time.
- If event has no `duration` the note will loop until another slice or the end of the pattern `duration`. 

This is a convenience to make it easier to loop a chunks of audio in a bigger pattern. For example, e.g. a 32 beat pattern with a simple 4-beat loop repeating and a 2-beat fill for the last 2 beats. 

```hjson
patterns: {
  beatWithFill: {
    ...
    duration: 32
    slices: [
      {
        start: 0
        beat: 0
        loop: 4
      }
      {
        start: 30
        beat: 30
        duration: 2
      }
    ]
  }
}
```