### PR TITLE
Use actual time to update UI progress 

### DIFF
--- a/src/apps/throwdown/components/midi-loop-player.js
+++ b/src/apps/throwdown/components/midi-loop-player.js
@@ -117,7 +117,7 @@ class MidiLoopPlayer {
       };
       // console.log(note.timestamp);
 
-      midiUtilities.renderNote( note, renderMsec.midiEventOffsetMsec );
+      midiUtilities.renderNote( note, renderMsec.midiEventOffset );
     }, _, patternDuration, channel ) );
   }
 }

--- a/src/apps/throwdown/index.js
+++ b/src/apps/throwdown/index.js
@@ -152,7 +152,7 @@ deckIndex++;
 // fileImport.importThrowdownFile( 'data/20190422--breakfast.hjson' );
 // fileImport.importThrowdownFile( 'data/20190325--alex-haszard-bdmt.hjson' );
 
-const initialTempo = 135;
+const initialTempo = 95;
 store.dispatch(
   transportActions.setTempo( initialTempo )
 );

--- a/src/apps/throwdown/throwdown-app.js
+++ b/src/apps/throwdown/throwdown-app.js
@@ -23,6 +23,7 @@ class ThrowdownApp {
     this.nextTempoBpm = null;
     this.tempoBpm = 120;
     this.lastRenderEndBeat = 0;
+    this.sequencerStartMsec = 0;
     this.midiOutPort = null;
 
     // we DO need to bind this
@@ -145,11 +146,16 @@ class ThrowdownApp {
 
     this.lastRenderEndBeat = renderRangeBeats.end;
 
+    // Update playback progress based on real time.
+    const uiProgressBeat = bpmUtilities.msToBeats(
+      this.tempoBpm,
+      renderRange.actualNow - this.sequencerStartMsec
+    );
     setTimeout( () => {
       store.dispatch(
-        transportActions.setCurrentBeat( this.lastRenderEndBeat )
+        transportActions.setCurrentBeat( uiProgressBeat )
       );
-    }, ( renderRange.end ) / 1000 );
+    }, renderRange.midiEventOffset );
   }
 
   sequencerCallback( renderRange ) {
@@ -240,6 +246,7 @@ class ThrowdownApp {
   // main
 
   startTransport() {
+    this.sequencerStartMsec = window.performance.now();
     sequencer.start();
   }
 

--- a/src/apps/throwdown/throwdown-app.js
+++ b/src/apps/throwdown/throwdown-app.js
@@ -145,23 +145,21 @@ class ThrowdownApp {
     this.updateDeckPlayState();
 
     this.lastRenderEndBeat = renderRangeBeats.end;
-
-    // Update playback progress based on real time.
-    const uiProgressBeat = bpmUtilities.msToBeats(
-      this.tempoBpm,
-      renderRange.actualNow - this.sequencerStartMsec
-    );
-    setTimeout( () => {
-      store.dispatch(
-        transportActions.setCurrentBeat( uiProgressBeat )
-      );
-    }, renderRange.midiEventOffset );
   }
 
   sequencerCallback( renderRange ) {
     this.renderIndex++;
 
     this.updateDeckPlayers( store.getState() );
+
+    // Update playback progress based on real time.
+    const uiProgressBeat = bpmUtilities.msToBeats(
+      this.tempoBpm,
+      ( renderRange.actualNow - this.sequencerStartMsec ) - renderRange.midiEventOffset
+    );
+    store.dispatch(
+      transportActions.setCurrentBeat( uiProgressBeat )
+    );
 
     // calculate render range in beats
     var chunkMs = renderRange.end - renderRange.start;

--- a/src/lib/kytaime/sequencer/sequencer.js
+++ b/src/lib/kytaime/sequencer/sequencer.js
@@ -102,6 +102,7 @@ var updateTransport = function() {
         actualNow: perfNow,
 
         // An offset to apply to midi events to keep them in sync with audio.
+        // This is the effective latency.
         midiEventOffset: audioContextOffsetSec * 1000,
       } );
     } );

--- a/src/lib/kytaime/sequencer/sequencer.js
+++ b/src/lib/kytaime/sequencer/sequencer.js
@@ -92,12 +92,17 @@ var updateTransport = function() {
       renderFunc( {
         audioContext: audioContext,
 
-        // audioContextTimeOffsetMsec: offsetMilliseconds,
-        // audioContextTimeOffsetMsec: audioContextOffsetSec * 1000,
-        midiEventOffsetMsec: audioContextOffsetSec * 1000,
+        // All the following values are in msec.
 
+        // The start & end time to render in msec - these are in the future.
         start: renderStart,
         end: renderEnd,
+
+        // The actual current time in msec - used to update UI in sync with scheduled audio/midi.
+        actualNow: perfNow,
+
+        // An offset to apply to midi events to keep them in sync with audio.
+        midiEventOffset: audioContextOffsetSec * 1000,
       } );
     } );
 


### PR DESCRIPTION
Fixes #117

Updates the UI progress using current actual time. Previously was using current render time (in the future) so was out of sync.